### PR TITLE
Fixes for Rebuild/Pstar value data biniding issues  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 
 # AGEPRO Changelog
 
+## 4.3.2 (2019-04-00)
+
+## Changes
+- Fixed an issue preventing AGEPRO Input Files with tabular whitespace delimiters to be loaded to GUI. 
+  - CoreLib: Replace space charcter to default (whitespace character delimitations) to split input fileline values. (#7)
+- Refactored StochasticWeightAge Input Data file loading code to be consistent with StochasticAgeTable, in Loading AGEPRO Input Files and setting user generated new cases.
+  - Call CreateStochasticAgeFallBackTable to handle Fleet Dependency and to remove redundancy. (#9)
+  - Renamed LoadWeightAgeInputData -> LoadStochasticWeightAgeInputData. 
+  - Set access to helper method CreateFallbackAgeTable to private.
+  - Cleaned up null checks
+- Replaced Nmfs.AGEPRO.GUI.ControlGeneral with Nmfs.AGEPRO.CoreLib.AgerproGeneral as the General Options class parameter of the  CreateStochasticParameterFallbackDataTable method to match consistency with Stochastic Data Tables.  
+- Prioritize binding CoreLib General Options Data over other AGEPRO parameters when setting user generated new cases. 
+- Simplfied the AGEPRO Input File Loading Exeception Dialog to error messages only.
+- Minor help manual updates and format tweaks. 
+
 ## 4.3.1 (2019-03-29)
 
 ## Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # AGEPRO Changelog
 
-## 4.3.2 (2019-04-00)
+## 4.3.2 (2019-07-01)
 
 ## Changes
 - Fixed an issue preventing AGEPRO Input Files with tabular whitespace delimiters to be loaded to GUI. 
@@ -12,8 +12,11 @@
   - Set access to helper method CreateFallbackAgeTable to private.
   - Cleaned up null checks
 - Replaced Nmfs.AGEPRO.GUI.ControlGeneral with Nmfs.AGEPRO.CoreLib.AgerproGeneral as the General Options class parameter of the  CreateStochasticParameterFallbackDataTable method to match consistency with Stochastic Data Tables.  
+- Fixed data binding issues for PStar and Rebuilder values.
+  - Fixed an issue where new/modified PStar or Rebuilder GUI input didn't save to input data file.
 - Prioritize binding CoreLib General Options Data over other AGEPRO parameters when setting user generated new cases. 
 - Simplfied the AGEPRO Input File Loading Exeception Dialog to error messages only.
+- Fixed Rebuilder option's Harvest Specification validation to begin on the 3rd projection year row.   
 - Minor help manual updates and format tweaks. 
 
 ## 4.3.1 (2019-03-29)

--- a/ControlHarvestCalcPStar.cs
+++ b/ControlHarvestCalcPStar.cs
@@ -13,11 +13,31 @@ namespace Nmfs.Agepro.Gui
     public partial class ControlHarvestCalcPStar : UserControl
     {
         private bool setControlValues;
+        public DataTable pstarLevelsTable { get; set; }
+
         public ControlHarvestCalcPStar()
         {
             InitializeComponent();
             setControlValues = false;
         }
+
+        public int pstarLevels 
+        { 
+            get{return Decimal.ToInt32(spinBoxNumPStarLevels.Value);} 
+            set{spinBoxNumPStarLevels.Value = value;} 
+        }
+        public string targetYear
+        {
+            get { return textBoxPStarTargetYear.Text; }
+            set { textBoxPStarTargetYear.Text = value; }
+        }
+        public string overfishingF
+        {
+            get { return textBoxOverfishingF.Text; }
+            set { textBoxOverfishingF.Text = value; }
+        }
+        
+     
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);

--- a/ControlHarvestCalcRebuilder.cs
+++ b/ControlHarvestCalcRebuilder.cs
@@ -28,6 +28,28 @@ namespace Nmfs.Agepro.Gui
             comboBoxRebuilderTargetType.DataSource = typeList;
         }
 
+        public string rebuilderTargetYear
+        {
+            get { return textBoxRebuilderTargetYear.Text; }
+            set { textBoxRebuilderTargetYear.Text = value; }
+        }
+
+        public string rebuilderBiomass
+        {
+            get { return textBoxRebuilderTargetBiomass.Text; }
+            set { textBoxRebuilderTargetBiomass.Text = value; }
+        }
+        public string rebuilderPercentConfidence
+        {
+            get { return textBoxRebuilderTargetPercent.Text; }
+            set { textBoxRebuilderTargetPercent.Text = value; }
+        }
+        public int rebuilderType
+        {
+            get { return comboBoxRebuilderTargetType.SelectedIndex; }
+            set { comboBoxRebuilderTargetType.SelectedIndex = value; }
+        }
+
         public void SetHarvestCalcRebuilderControls
             (Nmfs.Agepro.CoreLib.RebuilderTargetCalculation rebuilderTarget, Panel panelHarvestCalcParam)
         {

--- a/ControlHarvestCalcRebuilder.cs
+++ b/ControlHarvestCalcRebuilder.cs
@@ -26,6 +26,7 @@ namespace Nmfs.Agepro.Gui
             comboBoxRebuilderTargetType.ValueMember = "index";
             comboBoxRebuilderTargetType.DisplayMember = "rebuilderTargetTypeName";
             comboBoxRebuilderTargetType.DataSource = typeList;
+
         }
 
         public string rebuilderTargetYear

--- a/ControlHarvestScenario.cs
+++ b/ControlHarvestScenario.cs
@@ -27,7 +27,21 @@ namespace Nmfs.Agepro.Gui
             controlHarvestRebuilder = new ControlHarvestCalcRebuilder();
             controlHarvestPStar = new ControlHarvestCalcPStar();
             this.calcType = HarvestScenarioAnalysis.HarvestScenario;
+            this.Rebuilder = new Nmfs.Agepro.CoreLib.RebuilderTargetCalculation();
+            this.PStar = new Nmfs.Agepro.CoreLib.PStarCalculation();
+            this.seqYears = new string[1]{"1"};
+            
+            //PStar Defaults
+            this.controlHarvestPStar.pstarLevels = 1;
+            this.controlHarvestPStar.targetYear = "0";
+            this.controlHarvestPStar.overfishingF = "0.0";
+            //Nmfs.Agepro.CoreLib.Extensions.FillDBNullCellsWithZero(this.controlHarvestPStar.pstarLevelsTable);
 
+            //Rebuilder Defaults
+            this.controlHarvestRebuilder.rebuilderTargetYear = "0";
+            this.controlHarvestRebuilder.rebuilderBiomass = "0.0";
+            this.controlHarvestRebuilder.rebuilderPercentConfidence = "0.0";
+            this.controlHarvestRebuilder.rebuilderType = 0;
         }
 
         public DataTable HarvestScenarioTable

--- a/ControlHarvestScenario.cs
+++ b/ControlHarvestScenario.cs
@@ -19,12 +19,14 @@ namespace Nmfs.Agepro.Gui
         public string[] seqYears { get; set; }
         public Nmfs.Agepro.CoreLib.RebuilderTargetCalculation Rebuilder { get; set; }
         public Nmfs.Agepro.CoreLib.PStarCalculation PStar { get; set; }
+        public Nmfs.Agepro.CoreLib.HarvestScenarioAnalysis calcType { get; set; }
 
         public ControlHarvestScenario()
         {
             InitializeComponent();
             controlHarvestRebuilder = new ControlHarvestCalcRebuilder();
             controlHarvestPStar = new ControlHarvestCalcPStar();
+            calcType = HarvestScenarioAnalysis.HarvestScenario;
 
         }
 
@@ -147,7 +149,7 @@ namespace Nmfs.Agepro.Gui
         /// <param name="inputData"></param>
         public void SetHarvestScenarioCalcControls(Nmfs.Agepro.CoreLib.AgeproInputFile inpData)
         {
-            Nmfs.Agepro.CoreLib.HarvestScenarioAnalysis calcType = inpData.harvestScenario.analysisType;
+            this.calcType = inpData.harvestScenario.analysisType;
 
             //Clean out any previous instances of pstar and/or rebuilder. 
             if (this.PStar != null)

--- a/ControlHarvestScenario.cs
+++ b/ControlHarvestScenario.cs
@@ -145,7 +145,7 @@ namespace Nmfs.Agepro.Gui
         /// existing AGEPRO input file. 
         /// </summary>
         /// <param name="inputData"></param>
-        public void SetHarvestCalcuationOptionFromInput(Nmfs.Agepro.CoreLib.AgeproInputFile inpData)
+        public void SetHarvestScenarioCalcControls(Nmfs.Agepro.CoreLib.AgeproInputFile inpData)
         {
             Nmfs.Agepro.CoreLib.HarvestScenarioAnalysis calcType = inpData.harvestScenario.analysisType;
 

--- a/ControlHarvestScenario.cs
+++ b/ControlHarvestScenario.cs
@@ -26,7 +26,7 @@ namespace Nmfs.Agepro.Gui
             InitializeComponent();
             controlHarvestRebuilder = new ControlHarvestCalcRebuilder();
             controlHarvestPStar = new ControlHarvestCalcPStar();
-            calcType = HarvestScenarioAnalysis.HarvestScenario;
+            this.calcType = HarvestScenarioAnalysis.HarvestScenario;
 
         }
 
@@ -45,6 +45,7 @@ namespace Nmfs.Agepro.Gui
         private void radioNone_CheckedChanged(object sender, EventArgs e)
         {
             panelAltCalcParameters.Controls.Clear();
+            this.calcType = HarvestScenarioAnalysis.HarvestScenario;
         }
 
         /// <summary>
@@ -71,6 +72,7 @@ namespace Nmfs.Agepro.Gui
                         PStar.pStarTable.Rows.Add();
                         Nmfs.Agepro.CoreLib.Extensions.FillDBNullCellsWithZero(PStar.pStarTable);
                     }
+                    this.calcType = HarvestScenarioAnalysis.PStar;
                     controlHarvestPStar.SetHarvestCalcPStarControls(this.PStar, this.panelAltCalcParameters);
                 }
             }
@@ -100,7 +102,8 @@ namespace Nmfs.Agepro.Gui
                         Rebuilder.targetPercent = 0;
                         Rebuilder.obsYears = Array.ConvertAll(this.seqYears, int.Parse);
                     }
-                    controlHarvestRebuilder.SetHarvestCalcRebuilderControls(Rebuilder, this.panelAltCalcParameters);
+                    this.calcType = HarvestScenarioAnalysis.Rebuilder;
+                    controlHarvestRebuilder.SetHarvestCalcRebuilderControls(this.Rebuilder, this.panelAltCalcParameters);
                 }
             }
         }
@@ -137,9 +140,7 @@ namespace Nmfs.Agepro.Gui
             SetHarvestSpecificationColumn();
             
             this.HarvestScenarioTable = inpFileTable;
-            
         }
-
         
         
         /// <summary>

--- a/ControlHarvestScenario.cs
+++ b/ControlHarvestScenario.cs
@@ -267,7 +267,7 @@ namespace Nmfs.Agepro.Gui
                 //From year 2 to target year.
                 int nFMult = (this.Rebuilder.targetYear - this.Rebuilder.obsYears[0]);
                 List<string> invalidRowList = new List<string>();
-                for(int irow=1 ; irow < nFMult ; irow++) 
+                for(int irow=2 ; irow < nFMult ; irow++) 
                 {
                     if (this.HarvestScenarioTable.Rows[irow][0].Equals("F-MULT") == false)
                     {

--- a/ControlHarvestScenario.cs
+++ b/ControlHarvestScenario.cs
@@ -105,9 +105,7 @@ namespace Nmfs.Agepro.Gui
             {
                 if (rb.Checked)
                 {
-                    //If Rebuilder has no data, create an empty/default set. 
-                    //Otherwise load stored 'Rebuilder' class data to GUI.
-                    if (Rebuilder == null)
+                    if (this.Rebuilder == null)
                     {
                         Rebuilder = new RebuilderTargetCalculation();
                         Rebuilder.targetYear = 0;
@@ -185,7 +183,14 @@ namespace Nmfs.Agepro.Gui
             {
                 this.PStar = inpData.pstar;
                 radioPStar.Checked = true;
-                this.PStar.obsYears = Array.ConvertAll(this.seqYears, int.Parse);
+
+                //Create Defaluts if Pstar is null
+                if (PStar == null)
+                {
+                    PStar = new PStarCalculation();
+                    this.PStar.obsYears = inpData.general.SeqYears();
+                }
+
                 controlHarvestPStar.SetHarvestCalcPStarControls(this.PStar, this.panelAltCalcParameters);
             }
             else if (calcType == HarvestScenarioAnalysis.Rebuilder)
@@ -193,6 +198,14 @@ namespace Nmfs.Agepro.Gui
                 this.Rebuilder = inpData.rebuild;
                 radioRebuilderTarget.Checked = true;
                 this.Rebuilder.obsYears = Array.ConvertAll(this.seqYears, int.Parse);
+
+                //If Rebuilder has no data, create an empty/default set. 
+                if (this.Rebuilder == null)
+                {
+                    this.Rebuilder = new RebuilderTargetCalculation();
+                    this.Rebuilder.obsYears = inpData.general.SeqYears();
+                }
+
                 controlHarvestRebuilder.SetHarvestCalcRebuilderControls(this.Rebuilder, this.panelAltCalcParameters);
             }
         }

--- a/ControlHarvestScenario.cs
+++ b/ControlHarvestScenario.cs
@@ -180,6 +180,11 @@ namespace Nmfs.Agepro.Gui
             }
         }
 
+        /// <summary>
+        /// Helper Method to emumerate invalidation errors messages .
+        /// </summary>
+        /// <param name="invalidRowList"></param>
+        /// <returns></returns>
         private bool EnumerateInvalidRebuilderRangeRows(List<string> invalidRowList)
         {
             string overflowMsg = ".";
@@ -203,6 +208,10 @@ namespace Nmfs.Agepro.Gui
             return true;
         }
 
+        /// <summary>
+        /// Data Validation. 
+        /// </summary>
+        /// <returns></returns>
         public bool ValidateHarvestScenario()
         {
             if (this.dataGridHarvestScenarioTable.HasBlankOrNullCells())
@@ -268,7 +277,11 @@ namespace Nmfs.Agepro.Gui
             return true;
         }
 
-
+        /// <summary>
+        /// Cell Formmetting event event used to customise Harvest Scnario Data Grid View Headers
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void dataGridHarvestScenarioTable_CellFormatting(object sender, DataGridViewCellFormattingEventArgs e)
         {
             DataGridViewRowHeaderCell header = dataGridHarvestScenarioTable.Rows[e.RowIndex].HeaderCell;

--- a/FormAgepro.cs
+++ b/FormAgepro.cs
@@ -367,6 +367,25 @@ namespace Nmfs.Agepro.Gui
                         controlDiscardFraction.bindStochasticAgeData(this.inputData.discardFraction);     
                     }
 
+                    //Harvest Scenario: Rebuilder/PStar
+                    if (controlHarvestScenario.calcType == HarvestScenarioAnalysis.PStar)
+                    {
+                        this.inputData.harvestScenario.analysisType = controlHarvestScenario.calcType;
+                        this.inputData.pstar.analysisType = controlHarvestScenario.calcType;
+                        this.inputData.pstar.pStarLevels = controlHarvestScenario.PStar.pStarLevels;
+                        this.inputData.pstar.pStarF = controlHarvestScenario.PStar.pStarF;
+                        this.inputData.pstar.targetYear = controlHarvestScenario.PStar.targetYear;
+                        this.inputData.pstar.pStarTable = controlHarvestScenario.PStar.pStarTable;
+                    }
+                    else if (controlHarvestScenario.calcType == HarvestScenarioAnalysis.Rebuilder)
+                    {
+                        this.inputData.harvestScenario.analysisType = controlHarvestScenario.calcType;
+                        this.inputData.rebuild.analysisType = controlHarvestScenario.calcType;
+                        this.inputData.rebuild.targetYear = controlHarvestScenario.Rebuilder.targetYear;
+                        this.inputData.rebuild.targetPercent = controlHarvestScenario.Rebuilder.targetPercent;
+                        this.inputData.rebuild.targetType = controlHarvestScenario.Rebuilder.targetType;
+                    }
+
                     //Misc options
                     this.inputData.options.enableSummaryReport = controlMiscOptions.miscOptionsEnableSummaryReport;
                     this.inputData.options.enableExportR = controlMiscOptions.miscOptionsEnableExportR;

--- a/FormAgepro.cs
+++ b/FormAgepro.cs
@@ -250,7 +250,7 @@ namespace Nmfs.Agepro.Gui
                 //Set harvest calculations to "Harvest Scenario"/None by Default
                 controlHarvestScenario.seqYears = controlGeneralOptions.SeqYears();
                 inputData.harvestScenario.analysisType = HarvestScenarioAnalysis.HarvestScenario;
-                controlHarvestScenario.SetHarvestCalcuationOptionFromInput(inputData);
+                controlHarvestScenario.SetHarvestScenarioCalcControls(inputData);
                 DataTable userGenBasedHarvestScenarioTable = AgeproHarvestScenario.NewHarvestTable(
                     controlHarvestScenario.seqYears.Count(), 
                     Convert.ToInt32(controlGeneralOptions.generalNumberFleets));
@@ -474,7 +474,7 @@ namespace Nmfs.Agepro.Gui
             }
             controlHarvestScenario.seqYears = inpFile.recruitment.observationYears.Select(x => x.ToString()).ToArray();
             controlHarvestScenario.SetHarvestScenarioInputDataTable(inpFile.harvestScenario.harvestScenarioTable);
-            controlHarvestScenario.SetHarvestCalcuationOptionFromInput(inpFile);
+            controlHarvestScenario.SetHarvestScenarioCalcControls(inpFile);
 
 
             //Bootstrapping

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.3.2.0")]
-[assembly: AssemblyFileVersion("4.3.2.0")]
+[assembly: AssemblyVersion("4.3.2.2")]
+[assembly: AssemblyFileVersion("4.3.2.2")]


### PR DESCRIPTION
Fixex 
- Set Rebuider/Pstar default valuei. Important for new user generated AGEPRO cases.
- Rebuider/Pstar GUI input values go to the input data object before saved as AGEPRO input data file. 
- Rebuider Harvest Spec validation now begins at correct year row.(#11)