### PR TITLE
AGEPRO-GUI Support for OutputSummaryFlag/AuxiliaryOutputFlag changes for AGEPRO calculation engine version 4.25

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Does this same error happen when running one of [AGEPRO example model cases](https://github.com/PIFSCstockassessments/AGEPRO-GUI/blob/master/examples/exampleDocs.md)?
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Windows 11]
+ - AGEPRO-GUI Version [e.g. 4.3.5]
+
+**Additional context**
+Add any other context about the problem here.

--- a/AGEPRO_GUI.csproj
+++ b/AGEPRO_GUI.csproj
@@ -306,6 +306,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="src\ui\formAgepro\options\ControlMiscOptions.resx">
       <DependentUpon>ControlMiscOptions.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="src\ui\formAgepro\recruitment\ControlRecruitment.resx">
       <DependentUpon>ControlRecruitment.cs</DependentUpon>

--- a/AGEPRO_GUI.csproj
+++ b/AGEPRO_GUI.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Nmfs.Agepro.Gui</RootNamespace>
     <AssemblyName>AGEPRO</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>
@@ -28,6 +28,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x86</PlatformTarget>

--- a/AGEPRO_GUI.csproj
+++ b/AGEPRO_GUI.csproj
@@ -166,6 +166,7 @@
     </Compile>
     <Compile Include="src\ui\formAgepro\harvestScenario\HarvestSpecification.cs" />
     <Compile Include="src\ui\formAgepro\harvestScenario\RebuilderTargetType.cs" />
+    <Compile Include="src\ui\formAgepro\options\StockSummaryFlag.cs" />
     <Compile Include="src\ui\formAgepro\options\ControlMiscOptions.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/App.config
+++ b/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/Properties/Resources.Designer.cs
+++ b/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Nmfs.Agepro.Gui.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Nmfs.Agepro.Gui.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "12.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 ﻿# AGEPRO
 
-AGEPRO (Age Structured Projection Model) is a program designed to evaluate the likely population consequences of complex harvest scenarios under alternative hypotheses about the stock-recruitment relationship. Uncertainty in initial population size at age is incorporated into the model.
+This is a Windows-based Grahical interface of Jon Brodziak's AGEPRO (Age Structured Projection Model), which is designed to evaluate the likely population consequences of complex harvest scenarios under alternative hypotheses about the stock-recruitment relationship. Uncertainty in initial population size at age is incorporated into the model. This GUI is a revamp of the the original NOAA Fisheries National Fisheries Toolbox interface designed by Alan Seaver.
 
-AGEPRO Version 4.3.0 introduces a new interface, written in C#, modernizing the original NOAA Fisheries National Fisheries Toolbox interface designed by Alan Seaver.
+> [!NOTE]
+> AGEPRO-GUI is compatable with `AGEPRO VERSION 4.0` Input file format.  
+
 
 ## Github Disclaimer
 

--- a/Resources/AgeproStrings.Designer.cs
+++ b/Resources/AgeproStrings.Designer.cs
@@ -61,15 +61,6 @@ namespace Nmfs.Agepro.Gui.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 4.25.
-        /// </summary>
-        internal static string AGEPRO_Version {
-            get {
-                return ResourceManager.GetString("AGEPRO_Version", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Fraction Mortality Prior to Spawning.
         /// </summary>
         internal static string Bio_TSpawn_TextLabel {
@@ -84,24 +75,6 @@ namespace Nmfs.Agepro.Gui.Resources {
         internal static string CalcEnginePath {
             get {
                 return ResourceManager.GetString("CalcEnginePath", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to 4.25-4.3.5.
-        /// </summary>
-        internal static string GUI_Version {
-            get {
-                return ResourceManager.GetString("GUI_Version", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to AGEPRO VERSION 4.25.
-        /// </summary>
-        internal static string INPVersionString {
-            get {
-                return ResourceManager.GetString("INPVersionString", resourceCulture);
             }
         }
         

--- a/Resources/AgeproStrings.resx
+++ b/Resources/AgeproStrings.resx
@@ -117,21 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AGEPRO_Version" xml:space="preserve">
-    <value>4.25</value>
-    <comment>AGEPRO Calcuation Engine Version</comment>
-  </data>
   <data name="Bio_TSpawn_TextLabel" xml:space="preserve">
     <value>Fraction Mortality Prior to Spawning</value>
   </data>
   <data name="CalcEnginePath" xml:space="preserve">
     <value />
-  </data>
-  <data name="GUI_Version" xml:space="preserve">
-    <value>4.25-4.3.5</value>
-  </data>
-  <data name="INPVersionString" xml:space="preserve">
-    <value>AGEPRO VERSION 4.25</value>
   </data>
   <data name="ProgramName" xml:space="preserve">
     <value>AGEPRO</value>

--- a/src/NFT/NftTextBox.cs
+++ b/src/NFT/NftTextBox.cs
@@ -3,6 +3,10 @@ using System.Windows.Forms;
 
 namespace Nmfs.Agepro.Gui
 {
+  /// <summary>
+  /// This is an extension class of the System.Windows.Forms.TextBox. 
+  /// This includes basic validation and previous valid value. 
+  /// </summary>
   public class NftTextBox : TextBox
   {
 

--- a/src/NFT/NftTextBox.cs
+++ b/src/NFT/NftTextBox.cs
@@ -4,7 +4,7 @@ using System.Windows.Forms;
 namespace Nmfs.Agepro.Gui
 {
   /// <summary>
-  /// This is an extension class of the System.Windows.Forms.TextBox. 
+  /// This is an extension class of <see cref="System.Windows.Forms.TextBox"/> 
   /// This includes basic validation and previous valid value. 
   /// </summary>
   public class NftTextBox : TextBox

--- a/src/ui/about/AboutAgepro.cs
+++ b/src/ui/about/AboutAgepro.cs
@@ -57,7 +57,7 @@ namespace Nmfs.Agepro.Gui
       get
       {
         //return Assembly.GetExecutingAssembly().GetName().Version.ToString();
-        return Resources.AgeproStrings.GUI_Version;
+        return CoreLib.Resources.Version.GUI_Version;
       }
     }
 
@@ -136,7 +136,7 @@ namespace Nmfs.Agepro.Gui
     {
       //textBoxDescription: Override AssemblyDescription with this text.
       textBoxDescription.Text = $"GUI Version {AssemblyVersion}{Environment.NewLine}" +
-        $"AGEPRO Calcuation Engine Version {Resources.AgeproStrings.AGEPRO_Version}{Environment.NewLine}" +
+        $"AGEPRO Calcuation Engine Version {CoreLib.Resources.Version.AGEPRO_Version}{Environment.NewLine}" +
         $"{Environment.NewLine}" +
         $"AGEPRO Calculation Engine is built by Jon Brodziak.{Environment.NewLine}" +
         $"{Environment.NewLine}" +

--- a/src/ui/formAgepro/FormAgepro.cs
+++ b/src/ui/formAgepro/FormAgepro.cs
@@ -137,6 +137,7 @@ namespace Nmfs.Agepro.Gui
         controlMiscOptions.SetupScaleFactorsDataBindings(inputData.Scale);
         controlMiscOptions.SetupBoundsDataBindings(inputData.Bounds);
         controlGeneralOptions.SetupInpfileFormatTextBoxDataBindings(inputData);
+        controlMiscOptions.SetupMiscOptionsInpfileVerStringDataBindings(inputData);
       }
 
     }
@@ -490,6 +491,7 @@ namespace Nmfs.Agepro.Gui
       //Panel naigation functions 
       void SelectGeneralOptionsParameterPanel()
       {
+        controlGeneralOptions.GeneralInpfileFormatTextBoxString = inputData.Version;
         SelectAgeproParameterPanel(controlGeneralOptions, true);
       }
       void SelectJan1WeightsParameterPanel()

--- a/src/ui/formAgepro/FormAgepro.cs
+++ b/src/ui/formAgepro/FormAgepro.cs
@@ -136,6 +136,7 @@ namespace Nmfs.Agepro.Gui
         controlMiscOptions.SetupRefpointDataBindings(inputData.Refpoint);
         controlMiscOptions.SetupScaleFactorsDataBindings(inputData.Scale);
         controlMiscOptions.SetupBoundsDataBindings(inputData.Bounds);
+        controlGeneralOptions.SetupInpfileFormatTextBoxDataBindings(inputData);
       }
 
     }

--- a/src/ui/formAgepro/FormAgepro.cs
+++ b/src/ui/formAgepro/FormAgepro.cs
@@ -1,6 +1,7 @@
 ﻿using Nmfs.Agepro.CoreLib;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Windows.Forms;
@@ -260,41 +261,66 @@ namespace Nmfs.Agepro.Gui
     /// <returns></returns>
     private bool ValidateBootstrapFilename()
     {
+      DialogResult launchDialog;
       DialogResult bootstrapChoice;
 
       //Check Bootstrap File, but if value in textbox does not match, do not exit validation
       //Tell? user that they will have to supply bootstrap file.
-      if (!File.Exists(controlBootstrap.BootstrapFilename))
+
+      //Typically, AGEPRO model directories will contain a AGEPRO Input file, Bootstrap File, and Ouptut.
+      //This may used to check for Relative Paths for Bootstrap file paths in AGEPRO Input Files. 
+
+      //Conformation Dialog
+      launchDialog = MessageBox.Show($"Launching AGEPRO model with bootstrap file: {Environment.NewLine}"+
+        $"{inputData.Bootstrap.BootstrapFile}", 
+        "AGEPRO", MessageBoxButtons.OKCancel, MessageBoxIcon.Information);
+
+      if (launchDialog == DialogResult.Cancel)
       {
-        if (File.Exists($"{Path.GetDirectoryName(inputData.General.InputFile)}\\{Path.GetFileName(inputData.Bootstrap.BootstrapFile)}"))
+        return false;
+      }
+      
+      //Validation
+      if (File.Exists(inputData.Bootstrap.BootstrapFile))
+      {
+        return true;
+      }
+
+      if (File.Exists($"{Path.GetDirectoryName(inputData.General.InputFile)}\\{Path.GetFileName(inputData.Bootstrap.BootstrapFile)}"))
+      {
+        string inpFileDir = Path.GetDirectoryName(inputData.General.InputFile);
+        string bsnFileName = Path.GetFileName(inputData.Bootstrap.BootstrapFile);
+        bootstrapChoice = MessageBox.Show($"Bootstrap file was not found.{Environment.NewLine}" +
+          $"However, bootsrap file was found in the same directory of input file:{Environment.NewLine}" +
+          $"{Path.Combine(inpFileDir, bsnFileName)}{Environment.NewLine}{Environment.NewLine}"+
+          $"Set bootstap file to this path?",
+          "AGEPRO", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+
+        if (bootstrapChoice == DialogResult.Yes)
         {
-          string inpFileDir = Path.GetDirectoryName(inputData.General.InputFile);
-          string bsnFileName = Path.GetFileName(inputData.Bootstrap.BootstrapFile);
-          bootstrapChoice = MessageBox.Show($"Bootstrap filename was not found.{Environment.NewLine}" +
-            $"However, {bsnFileName} was found at {inpFileDir}{Environment.NewLine}{Environment.NewLine}Continue?",
+          //Set Bootsrapfile
+          controlBootstrap.BootstrapFilename = Path.Combine(inpFileDir, bsnFileName);
+
+          return true;
+        }
+
+      }
+      else
+      {
+        bootstrapChoice = MessageBox.Show(
+            $"Bootstrap file not found at:{Environment.NewLine}{controlBootstrap.BootstrapFilename}{Environment.NewLine}" +
+            $"Please select a new AGEPRO Bootstrap file to continue.{Environment.NewLine}{Environment.NewLine}Continue and load bootstrap file?",
             "AGEPRO", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 
-          if (bootstrapChoice == DialogResult.No)
-          {
-            return false;
-          }
-
-        }
-        else
+        if (bootstrapChoice == DialogResult.Yes)
         {
-          bootstrapChoice = MessageBox.Show(
-              $"Bootstrap file not found at:{Environment.NewLine}{controlBootstrap.BootstrapFilename}{Environment.NewLine}" +
-              $"Please select a new AGEPRO Bootstrap file to continue.{Environment.NewLine}{Environment.NewLine}Continue and load bootstrap file?",
-              "AGEPRO", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
-
-          if (bootstrapChoice == DialogResult.No)
-          {
-            return false;
-          }
+          return true;
         }
       }
 
-      return true;
+      return false;
+
+      
     }
 
 

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -112,7 +112,7 @@ namespace Nmfs.Agepro.Gui
     protected void SetAgeproModelFromUserInput()
     {
       //New Cases references version included in AGEPRO Reference Manual
-      inputData.Version = Resources.AgeproStrings.INPVersionString; // "AGEPRO VERSION 4.25"
+      inputData.Version = CoreLib.Resources.Version.INP_VersionString; // "AGEPRO VERSION 4.25"
 
       //Save General Options input to CoreLib Input Data Object
       inputData.General.ProjYearStart = Convert.ToInt32(controlGeneralOptions.GeneralFirstYearProjection);

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -212,6 +212,7 @@ namespace Nmfs.Agepro.Gui
       controlGeneralOptions.GeneralNumberPopulationSimuations = inpFile.General.NumPopSims.ToString();
       controlGeneralOptions.GeneralRandomSeed = inpFile.General.Seed.ToString();
       controlGeneralOptions.GeneralDiscardsPresent = inpFile.General.HasDiscards;
+      controlGeneralOptions.GeneralInputFile = inpFile.General.InputFile;
 
       //JAN-1
       controlJan1Weight.LoadStochasticWeightAgeInputData(inpFile.Jan1StockWeight, inpFile.General);

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -408,6 +408,14 @@ namespace Nmfs.Agepro.Gui
       double defaultMaxWeightBound = 10.0;
       double defaultNatualMortalityBound = 1.0;
 
+      //ObsYears
+      controlHarvestScenario.SeqYears = controlGeneralOptions.SeqYears();
+      int[] ObsYears = controlGeneralOptions.SeqYears()
+                                            .Where(s => int.TryParse(s, out _))
+                                            .Select(int.Parse)
+                                            .ToArray();
+      
+
       //Enforce Bounds defaults if option is unchecked
       switch (controlMiscOptions.MiscOptionsBounds)
       {
@@ -512,7 +520,7 @@ namespace Nmfs.Agepro.Gui
       //Bootstrap Filename validtion via this.ValidateBootstrapFilename()
 
       //Harvest Scenario (this includes Rebuilder and P-Star options)
-      if (controlHarvestScenario.ValidateHarvestScenario() == false)
+      if (controlHarvestScenario.ValidateHarvestScenario(ObsYears) == false)
       {
         return false;
       }

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -336,8 +336,9 @@ namespace Nmfs.Agepro.Gui
             inputData.HarvestScenario.AnalysisType = controlHarvestScenario.CalcType;
             inputData.Rebuild.AnalysisType = controlHarvestScenario.CalcType;
             inputData.Rebuild.TargetYear = controlHarvestScenario.Rebuilder.TargetYear;
-            inputData.Rebuild.TargetPercent = controlHarvestScenario.Rebuilder.TargetPercent;
+            inputData.Rebuild.TargetValue = controlHarvestScenario.Rebuilder.TargetValue;
             inputData.Rebuild.TargetType = controlHarvestScenario.Rebuilder.TargetType;
+            inputData.Rebuild.TargetPercent = controlHarvestScenario.Rebuilder.TargetPercent;
           }
 
           //Misc options

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -112,7 +112,7 @@ namespace Nmfs.Agepro.Gui
     protected void SetAgeproModelFromUserInput()
     {
       //New Cases references version included in AGEPRO Reference Manual
-      inputData.Version = "AGEPRO VERSION 4.25";
+      inputData.Version = Resources.AgeproStrings.INPVersionString; // "AGEPRO VERSION 4.25"
 
       //Save General Options input to CoreLib Input Data Object
       inputData.General.ProjYearStart = Convert.ToInt32(controlGeneralOptions.GeneralFirstYearProjection);

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -408,13 +408,7 @@ namespace Nmfs.Agepro.Gui
       double defaultMaxWeightBound = 10.0;
       double defaultNatualMortalityBound = 1.0;
 
-      //ObsYears
       controlHarvestScenario.SeqYears = controlGeneralOptions.SeqYears();
-      int[] ObsYears = controlGeneralOptions.SeqYears()
-                                            .Where(s => int.TryParse(s, out _))
-                                            .Select(int.Parse)
-                                            .ToArray();
-      
 
       //Enforce Bounds defaults if option is unchecked
       switch (controlMiscOptions.MiscOptionsBounds)
@@ -520,7 +514,7 @@ namespace Nmfs.Agepro.Gui
       //Bootstrap Filename validtion via this.ValidateBootstrapFilename()
 
       //Harvest Scenario (this includes Rebuilder and P-Star options)
-      if (controlHarvestScenario.ValidateHarvestScenario(ObsYears) == false)
+      if (controlHarvestScenario.ValidateHarvestScenario(controlGeneralOptions) == false)
       {
         return false;
       }

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -129,7 +129,7 @@ namespace Nmfs.Agepro.Gui
       inputData.CaseID = controlGeneralOptions.GeneralModelId;
 
       //Check for AGEPRO parameter data that has already been loaded/set 
-      controlMiscOptions.miscOptionsNAges = controlGeneralOptions.NumAges();
+      controlMiscOptions.miscOptionsNumAges = controlGeneralOptions.NumAges();
       controlMiscOptions.miscOptionsFirstAge = controlGeneralOptions.GeneralFirstAgeClass;
       controlMiscOptions.SetupSummaryStockFlagRadioButtons(inputData.Options);
 

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -269,7 +269,6 @@ namespace Nmfs.Agepro.Gui
 
       //Misc Options
       controlMiscOptions.SetMiscOptionsControlsFromInputFile(inpFile);
-      controlMiscOptions.SetupSummaryStockFlagRadioButtons(inpFile.Options);
 
       Console.WriteLine("Loaded AGEPRO Parameters ..");
     }

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -346,32 +346,8 @@ namespace Nmfs.Agepro.Gui
             inputData.Rebuild.TargetType = controlHarvestScenario.Rebuilder.TargetType;
           }
 
-          //Misc options
-          inputData.Options.EnableSummaryReport = controlMiscOptions.MiscOptionsEnableSummaryReport;
-          inputData.Options.EnableExportR = controlMiscOptions.MiscOptionsEnableExportR;
-          inputData.Options.EnableAuxStochasticFiles = controlMiscOptions.MiscOptionsEnableAuxStochasticFiles;
-          inputData.Options.EnablePercentileReport = controlMiscOptions.MiscOptionsEnablePercentileReport;
-          inputData.Options.EnableRefpoint = controlMiscOptions.MiscOptionsEnableRefpointsReport;
-          inputData.Options.EnableScaleFactors = controlMiscOptions.MiscOptionsEnableScaleFactors;
-          inputData.Options.EnableBounds = controlMiscOptions.MiscOptionsBounds;
-          inputData.Options.EnableRetroAdjustmentFactors = controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors;
-
-          //Misc Options: Refpoint
-          inputData.Refpoint.RefSpawnBio = double.Parse(controlMiscOptions.MiscOptionsRefSpawnBiomass);
-          inputData.Refpoint.RefJan1Bio = double.Parse(controlMiscOptions.MiscOptionsRefJan1Biomass);
-          inputData.Refpoint.RefMeanBio = double.Parse(controlMiscOptions.MiscOptionsRefMeanBiomass);
-          inputData.Refpoint.RefFMort = double.Parse(controlMiscOptions.MiscOptionsRefFishingMortality);
-
-          //Misc Options: Report Percentile
-          inputData.ReportPercentile.Percentile = controlMiscOptions.MiscOptionsReportPercentile;
-
-          //Misc Options: Scale Factors
-          inputData.Scale.ScaleBio = double.Parse(controlMiscOptions.MiscOptionsScaleFactorBiomass);
-          inputData.Scale.ScaleRec = double.Parse(controlMiscOptions.MiscOptionsScaleFactorRecruits);
-          inputData.Scale.ScaleStockNum = double.Parse(controlMiscOptions.MiscOptionsScaleFactorStockNumbers);
-
-          //Misc Options: Retro Adjustment Factors
-          inputData.RetroAdjustments.RetroAdjust = controlMiscOptions.MiscOptionsRetroAdjustmentFactorTable;
+          //Misc Options
+          controlMiscOptions.BindMiscOptionsControlValuesToCoreLib(inputData);
 
           inputData.WriteInputFile(saveAgeproInputFile.FileName);
 
@@ -390,6 +366,8 @@ namespace Nmfs.Agepro.Gui
       }
 
     }
+
+
 
     /*****************************************************************************************
      * VALAIDATION

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -55,6 +55,7 @@ namespace Nmfs.Agepro.Gui
       controlGeneralOptions.GeneralModelId = "untitled";
       inputData.General.InputFile = "";
       inputData.CaseID = controlGeneralOptions.GeneralModelId;
+      controlGeneralOptions.GeneralInpfileFormatTextBoxString = inputData.Version;
 
       //initially set Number of Ages
       _ = controlGeneralOptions.GeneralFirstAgeClass; //Spinbox Value
@@ -130,7 +131,7 @@ namespace Nmfs.Agepro.Gui
 
       //Check for AGEPRO parameter data that has already been loaded/set 
       controlMiscOptions.miscOptionsNumAges = controlGeneralOptions.NumAges();
-      controlMiscOptions.inpfileFormat = inputData.Version;
+      controlMiscOptions.MiscOptionsInpfileFormat = inputData.Version;
       controlMiscOptions.miscOptionsFirstAge = controlGeneralOptions.GeneralFirstAgeClass;
       controlMiscOptions.SetupGroupSummaryStockFlag(inputData.Options);
 
@@ -194,6 +195,7 @@ namespace Nmfs.Agepro.Gui
 
       //Bootstrap
       controlBootstrap.SetBootstrapControls(inputData.Bootstrap);
+      controlGeneralOptions.SetupInpfileFormatTextBoxDataBindings(inputData);
     }
 
     /// <summary>
@@ -217,6 +219,7 @@ namespace Nmfs.Agepro.Gui
       controlGeneralOptions.GeneralRandomSeed = inpFile.General.Seed.ToString();
       controlGeneralOptions.GeneralDiscardsPresent = inpFile.General.HasDiscards;
       controlGeneralOptions.GeneralInputFile = inpFile.General.InputFile;
+      controlGeneralOptions.GeneralInpfileFormatTextBoxString = inpFile.Version;
 
       //JAN-1
       controlJan1Weight.LoadStochasticWeightAgeInputData(inpFile.Jan1StockWeight, inpFile.General);
@@ -273,7 +276,7 @@ namespace Nmfs.Agepro.Gui
       controlBootstrap.BootstrapScaleFactors = inpFile.Bootstrap.PopScaleFactor.ToString();
 
       //Misc Options
-      controlMiscOptions.inpfileFormat = inpFile.Version;
+      controlMiscOptions.MiscOptionsInpfileFormat = inpFile.Version;
       controlMiscOptions.SetupControlFromFile(inpFile);
 
       Console.WriteLine("Loaded AGEPRO Parameters ..");
@@ -361,13 +364,15 @@ namespace Nmfs.Agepro.Gui
             //Misc Options: Enable Summary Report (AGEPRO VERSION 4.0)
             inputData.Options.EnableSummaryReport = Convert.ToBoolean((int)controlMiscOptions.SummaryAuxFileOutputFlag);
             inputData.Version = CoreLib.Resources.Version.INP_AGEPRO40_VersionString;
+            controlGeneralOptions.GeneralInpfileFormatTextBoxString = inputData.Version;
           }
           else
           {
             //Misc Options: Auxilary Output Flag (AGEPRO VERSION 4.25+)
             inputData.Options.OutputSummaryReport = (int)controlMiscOptions.SummaryAuxFileOutputFlag;
             //Points to the current Input file format version string in INP_VersionString
-            inputData.Version = CoreLib.Resources.Version.INP_VersionString; 
+            inputData.Version = CoreLib.Resources.Version.INP_VersionString;
+            controlGeneralOptions.GeneralInpfileFormatTextBoxString = inputData.Version;
           }
 
             

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -363,6 +363,7 @@ namespace Nmfs.Agepro.Gui
           {
             //Misc Options: Enable Summary Report (AGEPRO VERSION 4.0)
             inputData.Options.EnableSummaryReport = Convert.ToBoolean((int)controlMiscOptions.SummaryAuxFileOutputFlag);
+            inputData.Options.OutputSummaryReport = (int)controlMiscOptions.SummaryAuxFileOutputFlag; //catch non-compat values
             inputData.Version = CoreLib.Resources.Version.INP_AGEPRO40_VersionString;
             controlGeneralOptions.GeneralInpfileFormatTextBoxString = inputData.Version;
           }

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -136,15 +136,7 @@ namespace Nmfs.Agepro.Gui
       //Retro Adjustment Factors
       if (controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors)
       {
-        //In case NumAges is larger than previous row count, "reset" dataGridView 
-        if (controlMiscOptions.MiscOptionsRetroAdjustmentFactorTable != null
-          && controlGeneralOptions.NumAges() > controlMiscOptions.MiscOptionsRetroAdjustmentFactorTable.Rows.Count)
-        {
-          controlMiscOptions.MiscOptionsRetroAdjustmentFactorTable.Reset();
-        }
-        controlMiscOptions.MiscOptionsRetroAdjustmentFactorTable =
-            controlMiscOptions.GetRetroAdjustmentFallbackTable(controlMiscOptions.miscOptionsNAges);
-        controlMiscOptions.SetRetroAdjustmentFactorRowHeaders();
+        controlMiscOptions.SetupRetroAdjustmentFactorsControlFromUserInput(controlGeneralOptions);
       }
 
       //Set Stochastic Paramaeter DataGrids           

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -340,7 +340,7 @@ namespace Nmfs.Agepro.Gui
           }
 
           //Misc Options
-          controlMiscOptions.BindMiscOptionsControlValuesToCoreLib(inputData);
+          controlMiscOptions.ControlMiscOptionsDataBindings(inputData);
 
           inputData.WriteInputFile(saveAgeproInputFile.FileName);
 

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -275,37 +275,7 @@ namespace Nmfs.Agepro.Gui
       controlBootstrap.BootstrapScaleFactors = inpFile.Bootstrap.PopScaleFactor.ToString();
 
       //Misc Options
-      controlMiscOptions.MiscOptionsEnableSummaryReport = inpFile.Options.EnableSummaryReport;
-      controlMiscOptions.MiscOptionsEnableAuxStochasticFiles = inpFile.Options.EnableAuxStochasticFiles;
-      controlMiscOptions.MiscOptionsEnableExportR = inpFile.Options.EnableExportR;
-      controlMiscOptions.MiscOptionsEnablePercentileReport = inpFile.Options.EnablePercentileReport;
-      controlMiscOptions.MiscOptionsReportPercentile = Convert.ToDouble(inpFile.ReportPercentile.Percentile);
-
-      controlMiscOptions.MiscOptionsEnableRefpointsReport = inpFile.Options.EnableRefpoint;
-      controlMiscOptions.MiscOptionsRefSpawnBiomass = inpFile.Refpoint.RefSpawnBio.ToString();
-      controlMiscOptions.MiscOptionsRefJan1Biomass = inpFile.Refpoint.RefJan1Bio.ToString();
-      controlMiscOptions.MiscOptionsRefMeanBiomass = inpFile.Refpoint.RefMeanBio.ToString();
-      controlMiscOptions.MiscOptionsRefFishingMortality = inpFile.Refpoint.RefFMort.ToString();
-
-      controlMiscOptions.MiscOptionsEnableScaleFactors = inpFile.Options.EnableScaleFactors;
-      controlMiscOptions.MiscOptionsScaleFactorBiomass = inpFile.Scale.ScaleBio.ToString();
-      controlMiscOptions.MiscOptionsScaleFactorRecruits = inpFile.Scale.ScaleRec.ToString();
-      controlMiscOptions.MiscOptionsScaleFactorStockNumbers = inpFile.Scale.ScaleStockNum.ToString();
-
-      controlMiscOptions.MiscOptionsBounds = inpFile.Options.EnableBounds;
-      controlMiscOptions.MiscOptionsBoundsMaxWeight = inpFile.Bounds.MaxWeight.ToString();
-      controlMiscOptions.MiscOptionsBoundsNaturalMortality = inpFile.Bounds.MaxNatMort.ToString();
-
-      controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors = inpFile.Options.EnableRetroAdjustmentFactors;
-      controlMiscOptions.miscOptionsNAges = inpFile.General.NumAges();
-      controlMiscOptions.miscOptionsFirstAge = inpFile.General.AgeBegin;
-
-      controlMiscOptions.LoadRetroAdjustmentsFactorTable(inpFile);
-
-      if (controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors)
-      {
-        controlMiscOptions.SetRetroAdjustmentFactorRowHeaders();
-      }
+      controlMiscOptions.SetMiscOptionsControlsFromInputFile(inpFile);
 
       Console.WriteLine("Loaded AGEPRO Parameters ..");
     }

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -268,7 +268,7 @@ namespace Nmfs.Agepro.Gui
       controlBootstrap.BootstrapScaleFactors = inpFile.Bootstrap.PopScaleFactor.ToString();
 
       //Misc Options
-      controlMiscOptions.SetMiscOptionsControlsFromInputFile(inpFile);
+      controlMiscOptions.SetupControlFromFile(inpFile);
 
       Console.WriteLine("Loaded AGEPRO Parameters ..");
     }

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -136,7 +136,7 @@ namespace Nmfs.Agepro.Gui
       //Retro Adjustment Factors
       if (controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors)
       {
-        controlMiscOptions.SetupRetroAdjustmentFactorsControlFromUserInput(controlGeneralOptions);
+        controlMiscOptions.SetupRetroAdjustmentsFactorControl(controlGeneralOptions);
       }
 
       //Set Stochastic Paramaeter DataGrids           

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -197,11 +197,14 @@ namespace Nmfs.Agepro.Gui
     }
 
     /// <summary>
-    /// Load AGEPRO InputFile data into AGEPRO Parameter Controls
+    /// Load AGEPRO InputFile data into AGEPRO Parameter Controls. 
+    /// 
+    /// Input version format check is done previously by "ReadInputFile"
     /// </summary>
     /// <param name="inpFile">AGEPRO CoreLib InputFile</param>
     protected void LoadAgeproModelFromInputFile(AgeproInputFile inpFile)
     {
+
       //General Options
       controlGeneralOptions.GeneralModelId = inpFile.CaseID;
       controlGeneralOptions.GeneralFirstYearProjection = inpFile.General.ProjYearStart.ToString();

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -131,7 +131,7 @@ namespace Nmfs.Agepro.Gui
       //Check for AGEPRO parameter data that has already been loaded/set 
       controlMiscOptions.miscOptionsNumAges = controlGeneralOptions.NumAges();
       controlMiscOptions.miscOptionsFirstAge = controlGeneralOptions.GeneralFirstAgeClass;
-      controlMiscOptions.SetupSummaryStockFlagRadioButtons(inputData.Options);
+      controlMiscOptions.SetupGroupSummaryStockFlag(inputData.Options);
 
       //Retro Adjustment Factors
       if (controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors)

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -136,7 +136,7 @@ namespace Nmfs.Agepro.Gui
       //Retro Adjustment Factors
       if (controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors)
       {
-        controlMiscOptions.SetupRetroAdjustmentsFactorControl(controlGeneralOptions);
+        controlMiscOptions.SetupRetroAdjustmentControl(controlGeneralOptions);
       }
 
       //Set Stochastic Paramaeter DataGrids           

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -273,6 +273,7 @@ namespace Nmfs.Agepro.Gui
       controlBootstrap.BootstrapScaleFactors = inpFile.Bootstrap.PopScaleFactor.ToString();
 
       //Misc Options
+      controlMiscOptions.inpfileFormat = inpFile.Version;
       controlMiscOptions.SetupControlFromFile(inpFile);
 
       Console.WriteLine("Loaded AGEPRO Parameters ..");
@@ -353,6 +354,23 @@ namespace Nmfs.Agepro.Gui
           inputData.Options.EnableScaleFactors = controlMiscOptions.MiscOptionsEnableScaleFactors;
           inputData.Options.EnableBounds = controlMiscOptions.MiscOptionsBounds;
           inputData.Options.EnableRetroAdjustmentFactors = controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors;
+
+
+          if (controlMiscOptions.MiscOptionsEnableVer40Format)
+          {
+            //Misc Options: Enable Summary Report (AGEPRO VERSION 4.0)
+            inputData.Options.EnableSummaryReport = Convert.ToBoolean((int)controlMiscOptions.SummaryAuxFileOutputFlag);
+            inputData.Version = CoreLib.Resources.Version.INP_AGEPRO40_VersionString;
+          }
+          else
+          {
+            //Misc Options: Auxilary Output Flag (AGEPRO VERSION 4.25+)
+            inputData.Options.OutputSummaryReport = (int)controlMiscOptions.SummaryAuxFileOutputFlag;
+            //Points to the current Input file format version string in INP_VersionString
+            inputData.Version = CoreLib.Resources.Version.INP_VersionString; 
+          }
+
+            
 
           //Misc Options: Refpoint
           inputData.Refpoint.RefSpawnBio = double.Parse(controlMiscOptions.MiscOptionsRefSpawnBiomass);

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -130,6 +130,7 @@ namespace Nmfs.Agepro.Gui
 
       //Check for AGEPRO parameter data that has already been loaded/set 
       controlMiscOptions.miscOptionsNumAges = controlGeneralOptions.NumAges();
+      controlMiscOptions.inpfileFormat = inputData.Version;
       controlMiscOptions.miscOptionsFirstAge = controlGeneralOptions.GeneralFirstAgeClass;
       controlMiscOptions.SetupGroupSummaryStockFlag(inputData.Options);
 

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -340,7 +340,6 @@ namespace Nmfs.Agepro.Gui
           }
 
           //Misc options
-          inputData.Options.EnableSummaryReport = controlMiscOptions.MiscOptionsEnableSummaryReport;
           inputData.Options.EnableExportR = controlMiscOptions.MiscOptionsEnableExportR;
           inputData.Options.EnableAuxStochasticFiles = controlMiscOptions.MiscOptionsEnableAuxStochasticFiles;
           inputData.Options.EnablePercentileReport = controlMiscOptions.MiscOptionsEnablePercentileReport;

--- a/src/ui/formAgepro/FormAgeproBase.cs
+++ b/src/ui/formAgepro/FormAgeproBase.cs
@@ -131,6 +131,7 @@ namespace Nmfs.Agepro.Gui
       //Check for AGEPRO parameter data that has already been loaded/set 
       controlMiscOptions.miscOptionsNAges = controlGeneralOptions.NumAges();
       controlMiscOptions.miscOptionsFirstAge = controlGeneralOptions.GeneralFirstAgeClass;
+      controlMiscOptions.SetupSummaryStockFlagRadioButtons(inputData.Options);
 
       //Retro Adjustment Factors
       if (controlMiscOptions.MiscOptionsEnableRetroAdjustmentFactors)
@@ -276,6 +277,7 @@ namespace Nmfs.Agepro.Gui
 
       //Misc Options
       controlMiscOptions.SetMiscOptionsControlsFromInputFile(inpFile);
+      controlMiscOptions.SetupSummaryStockFlagRadioButtons(inpFile.Options);
 
       Console.WriteLine("Loaded AGEPRO Parameters ..");
     }

--- a/src/ui/formAgepro/general-startup/ControlGeneral.Designer.cs
+++ b/src/ui/formAgepro/general-startup/ControlGeneral.Designer.cs
@@ -28,333 +28,348 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.groupGeneralOptions = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanelGeneralOptions = new System.Windows.Forms.TableLayoutPanel();
-            this.labelFirstYearProjection = new System.Windows.Forms.Label();
-            this.buttonSetGeneral = new System.Windows.Forms.Button();
-            this.spinBoxFirstAge = new System.Windows.Forms.NumericUpDown();
-            this.checkBoxDiscards = new System.Windows.Forms.CheckBox();
-            this.textBoxNumRecruitModels = new System.Windows.Forms.TextBox();
-            this.textBoxRandomSeed = new System.Windows.Forms.TextBox();
-            this.textBoxFirstYearProjection = new System.Windows.Forms.TextBox();
-            this.labelRandomSeed = new System.Windows.Forms.Label();
-            this.textBoxLastAge = new System.Windows.Forms.TextBox();
-            this.labelNumFleets = new System.Windows.Forms.Label();
-            this.textBoxNumFleets = new System.Windows.Forms.TextBox();
-            this.labelLastAge = new System.Windows.Forms.Label();
-            this.labelNumPopSim = new System.Windows.Forms.Label();
-            this.labelNumRecruitModels = new System.Windows.Forms.Label();
-            this.textBoxNumPopSim = new System.Windows.Forms.TextBox();
-            this.textBoxLastYearProjection = new System.Windows.Forms.TextBox();
-            this.labelFirstAge = new System.Windows.Forms.Label();
-            this.labelLastYearProjection = new System.Windows.Forms.Label();
-            this.labelModelID = new System.Windows.Forms.Label();
-            this.labelInputFile = new System.Windows.Forms.Label();
-            this.textBoxModelID = new System.Windows.Forms.TextBox();
-            this.textBoxInputFile = new Nmfs.Agepro.Gui.NftTextBox();
-            this.groupGeneralOptions.SuspendLayout();
-            this.tableLayoutPanelGeneralOptions.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.spinBoxFirstAge)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // groupGeneralOptions
-            // 
-            this.groupGeneralOptions.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupGeneralOptions.Controls.Add(this.tableLayoutPanelGeneralOptions);
-            this.groupGeneralOptions.Location = new System.Drawing.Point(58, 262);
-            this.groupGeneralOptions.Name = "groupGeneralOptions";
-            this.groupGeneralOptions.Size = new System.Drawing.Size(786, 221);
-            this.groupGeneralOptions.TabIndex = 5;
-            this.groupGeneralOptions.TabStop = false;
-            this.groupGeneralOptions.Text = "Options";
-            // 
-            // tableLayoutPanelGeneralOptions
-            // 
-            this.tableLayoutPanelGeneralOptions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+      this.groupGeneralOptions = new System.Windows.Forms.GroupBox();
+      this.tableLayoutPanelGeneralOptions = new System.Windows.Forms.TableLayoutPanel();
+      this.labelFirstYearProjection = new System.Windows.Forms.Label();
+      this.buttonSetGeneral = new System.Windows.Forms.Button();
+      this.spinBoxFirstAge = new System.Windows.Forms.NumericUpDown();
+      this.checkBoxDiscards = new System.Windows.Forms.CheckBox();
+      this.textBoxNumRecruitModels = new System.Windows.Forms.TextBox();
+      this.textBoxRandomSeed = new System.Windows.Forms.TextBox();
+      this.textBoxFirstYearProjection = new System.Windows.Forms.TextBox();
+      this.labelRandomSeed = new System.Windows.Forms.Label();
+      this.textBoxLastAge = new System.Windows.Forms.TextBox();
+      this.labelNumFleets = new System.Windows.Forms.Label();
+      this.textBoxNumFleets = new System.Windows.Forms.TextBox();
+      this.labelLastAge = new System.Windows.Forms.Label();
+      this.labelNumPopSim = new System.Windows.Forms.Label();
+      this.labelNumRecruitModels = new System.Windows.Forms.Label();
+      this.textBoxNumPopSim = new System.Windows.Forms.TextBox();
+      this.textBoxLastYearProjection = new System.Windows.Forms.TextBox();
+      this.labelFirstAge = new System.Windows.Forms.Label();
+      this.labelLastYearProjection = new System.Windows.Forms.Label();
+      this.labelModelID = new System.Windows.Forms.Label();
+      this.labelInputFile = new System.Windows.Forms.Label();
+      this.textBoxModelID = new System.Windows.Forms.TextBox();
+      this.textBoxInputFile = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxInpfileFormat = new Nmfs.Agepro.Gui.NftTextBox();
+      this.groupGeneralOptions.SuspendLayout();
+      this.tableLayoutPanelGeneralOptions.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.spinBoxFirstAge)).BeginInit();
+      this.SuspendLayout();
+      // 
+      // groupGeneralOptions
+      // 
+      this.groupGeneralOptions.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+      this.groupGeneralOptions.Controls.Add(this.tableLayoutPanelGeneralOptions);
+      this.groupGeneralOptions.Location = new System.Drawing.Point(58, 262);
+      this.groupGeneralOptions.Name = "groupGeneralOptions";
+      this.groupGeneralOptions.Size = new System.Drawing.Size(786, 221);
+      this.groupGeneralOptions.TabIndex = 5;
+      this.groupGeneralOptions.TabStop = false;
+      this.groupGeneralOptions.Text = "Options";
+      // 
+      // tableLayoutPanelGeneralOptions
+      // 
+      this.tableLayoutPanelGeneralOptions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.tableLayoutPanelGeneralOptions.ColumnCount = 8;
-            this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 6.068862F));
-            this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 5.057385F));
-            this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 19.21806F));
-            this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 19.22256F));
-            this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 65F));
-            this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 23.53583F));
-            this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 19.22257F));
-            this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 7.674728F));
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelFirstYearProjection, 2, 0);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.buttonSetGeneral, 6, 4);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.spinBoxFirstAge, 3, 2);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.checkBoxDiscards, 2, 4);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxNumRecruitModels, 6, 1);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxRandomSeed, 6, 3);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxFirstYearProjection, 3, 0);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelRandomSeed, 5, 3);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxLastAge, 3, 3);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelNumFleets, 5, 0);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxNumFleets, 6, 0);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelLastAge, 2, 3);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelNumPopSim, 5, 2);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelNumRecruitModels, 5, 1);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxNumPopSim, 6, 2);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxLastYearProjection, 3, 1);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelFirstAge, 2, 2);
-            this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelLastYearProjection, 2, 1);
-            this.tableLayoutPanelGeneralOptions.Location = new System.Drawing.Point(6, 34);
-            this.tableLayoutPanelGeneralOptions.Name = "tableLayoutPanelGeneralOptions";
-            this.tableLayoutPanelGeneralOptions.RowCount = 5;
-            this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 19.79105F));
-            this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 19.79073F));
-            this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 19.79073F));
-            this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 19.79481F));
-            this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20.83268F));
-            this.tableLayoutPanelGeneralOptions.Size = new System.Drawing.Size(774, 157);
-            this.tableLayoutPanelGeneralOptions.TabIndex = 18;
-            // 
-            // labelFirstYearProjection
-            // 
-            this.labelFirstYearProjection.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelFirstYearProjection.AutoSize = true;
-            this.labelFirstYearProjection.Location = new System.Drawing.Point(81, 9);
-            this.labelFirstYearProjection.Name = "labelFirstYearProjection";
-            this.labelFirstYearProjection.Size = new System.Drawing.Size(113, 13);
-            this.labelFirstYearProjection.TabIndex = 0;
-            this.labelFirstYearProjection.Text = "First Year In Projection";
-            // 
-            // buttonSetGeneral
-            // 
-            this.buttonSetGeneral.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.buttonSetGeneral.Location = new System.Drawing.Point(611, 129);
-            this.buttonSetGeneral.MinimumSize = new System.Drawing.Size(75, 23);
-            this.buttonSetGeneral.Name = "buttonSetGeneral";
-            this.buttonSetGeneral.Size = new System.Drawing.Size(75, 23);
-            this.buttonSetGeneral.TabIndex = 17;
-            this.buttonSetGeneral.Text = "SET";
-            this.buttonSetGeneral.UseVisualStyleBackColor = true;
-            this.buttonSetGeneral.Click += new System.EventHandler(this.ButtonSetGeneral_Click);
-            // 
-            // spinBoxFirstAge
-            // 
-            this.spinBoxFirstAge.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.spinBoxFirstAge.Location = new System.Drawing.Point(217, 67);
-            this.spinBoxFirstAge.Maximum = new decimal(new int[] {
+      this.tableLayoutPanelGeneralOptions.ColumnCount = 8;
+      this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 6.068862F));
+      this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 5.057385F));
+      this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 19.21806F));
+      this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 19.22256F));
+      this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 65F));
+      this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 23.53583F));
+      this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 19.22257F));
+      this.tableLayoutPanelGeneralOptions.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 7.674728F));
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelFirstYearProjection, 2, 0);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.buttonSetGeneral, 6, 4);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.spinBoxFirstAge, 3, 2);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.checkBoxDiscards, 2, 4);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxNumRecruitModels, 6, 1);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxRandomSeed, 6, 3);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxFirstYearProjection, 3, 0);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelRandomSeed, 5, 3);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxLastAge, 3, 3);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelNumFleets, 5, 0);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxNumFleets, 6, 0);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelLastAge, 2, 3);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelNumPopSim, 5, 2);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelNumRecruitModels, 5, 1);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxNumPopSim, 6, 2);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.textBoxLastYearProjection, 3, 1);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelFirstAge, 2, 2);
+      this.tableLayoutPanelGeneralOptions.Controls.Add(this.labelLastYearProjection, 2, 1);
+      this.tableLayoutPanelGeneralOptions.Location = new System.Drawing.Point(6, 34);
+      this.tableLayoutPanelGeneralOptions.Name = "tableLayoutPanelGeneralOptions";
+      this.tableLayoutPanelGeneralOptions.RowCount = 5;
+      this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 19.79105F));
+      this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 19.79073F));
+      this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 19.79073F));
+      this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 19.79481F));
+      this.tableLayoutPanelGeneralOptions.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 20.83268F));
+      this.tableLayoutPanelGeneralOptions.Size = new System.Drawing.Size(774, 157);
+      this.tableLayoutPanelGeneralOptions.TabIndex = 18;
+      // 
+      // labelFirstYearProjection
+      // 
+      this.labelFirstYearProjection.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelFirstYearProjection.AutoSize = true;
+      this.labelFirstYearProjection.Location = new System.Drawing.Point(81, 9);
+      this.labelFirstYearProjection.Name = "labelFirstYearProjection";
+      this.labelFirstYearProjection.Size = new System.Drawing.Size(113, 13);
+      this.labelFirstYearProjection.TabIndex = 0;
+      this.labelFirstYearProjection.Text = "First Year In Projection";
+      // 
+      // buttonSetGeneral
+      // 
+      this.buttonSetGeneral.Anchor = System.Windows.Forms.AnchorStyles.None;
+      this.buttonSetGeneral.Location = new System.Drawing.Point(611, 129);
+      this.buttonSetGeneral.MinimumSize = new System.Drawing.Size(75, 23);
+      this.buttonSetGeneral.Name = "buttonSetGeneral";
+      this.buttonSetGeneral.Size = new System.Drawing.Size(75, 23);
+      this.buttonSetGeneral.TabIndex = 17;
+      this.buttonSetGeneral.Text = "SET";
+      this.buttonSetGeneral.UseVisualStyleBackColor = true;
+      this.buttonSetGeneral.Click += new System.EventHandler(this.ButtonSetGeneral_Click);
+      // 
+      // spinBoxFirstAge
+      // 
+      this.spinBoxFirstAge.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.spinBoxFirstAge.Location = new System.Drawing.Point(217, 67);
+      this.spinBoxFirstAge.Maximum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            this.spinBoxFirstAge.MinimumSize = new System.Drawing.Size(120, 0);
-            this.spinBoxFirstAge.Name = "spinBoxFirstAge";
-            this.spinBoxFirstAge.Size = new System.Drawing.Size(120, 20);
-            this.spinBoxFirstAge.TabIndex = 5;
-            this.spinBoxFirstAge.Value = new decimal(new int[] {
+      this.spinBoxFirstAge.MinimumSize = new System.Drawing.Size(120, 0);
+      this.spinBoxFirstAge.Name = "spinBoxFirstAge";
+      this.spinBoxFirstAge.Size = new System.Drawing.Size(120, 20);
+      this.spinBoxFirstAge.TabIndex = 5;
+      this.spinBoxFirstAge.Value = new decimal(new int[] {
             1,
             0,
             0,
             0});
-            // 
-            // checkBoxDiscards
-            // 
-            this.checkBoxDiscards.AccessibleDescription = "";
-            this.checkBoxDiscards.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBoxDiscards.AutoSize = true;
-            this.checkBoxDiscards.Location = new System.Drawing.Point(81, 132);
-            this.checkBoxDiscards.MinimumSize = new System.Drawing.Size(127, 17);
-            this.checkBoxDiscards.Name = "checkBoxDiscards";
-            this.checkBoxDiscards.Size = new System.Drawing.Size(127, 17);
-            this.checkBoxDiscards.TabIndex = 8;
-            this.checkBoxDiscards.Text = "Discards are Present";
-            this.checkBoxDiscards.UseVisualStyleBackColor = true;
-            // 
-            // textBoxNumRecruitModels
-            // 
-            this.textBoxNumRecruitModels.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.textBoxNumRecruitModels.Location = new System.Drawing.Point(584, 36);
-            this.textBoxNumRecruitModels.MinimumSize = new System.Drawing.Size(120, 20);
-            this.textBoxNumRecruitModels.Name = "textBoxNumRecruitModels";
-            this.textBoxNumRecruitModels.Size = new System.Drawing.Size(120, 20);
-            this.textBoxNumRecruitModels.TabIndex = 12;
-            this.textBoxNumRecruitModels.Text = "1";
-            // 
-            // textBoxRandomSeed
-            // 
-            this.textBoxRandomSeed.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.textBoxRandomSeed.Location = new System.Drawing.Point(584, 98);
-            this.textBoxRandomSeed.MinimumSize = new System.Drawing.Size(120, 20);
-            this.textBoxRandomSeed.Name = "textBoxRandomSeed";
-            this.textBoxRandomSeed.Size = new System.Drawing.Size(120, 20);
-            this.textBoxRandomSeed.TabIndex = 16;
-            this.textBoxRandomSeed.Text = "0";
-            // 
-            // textBoxFirstYearProjection
-            // 
-            this.textBoxFirstYearProjection.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.textBoxFirstYearProjection.Location = new System.Drawing.Point(217, 5);
-            this.textBoxFirstYearProjection.MinimumSize = new System.Drawing.Size(120, 20);
-            this.textBoxFirstYearProjection.Name = "textBoxFirstYearProjection";
-            this.textBoxFirstYearProjection.Size = new System.Drawing.Size(120, 20);
-            this.textBoxFirstYearProjection.TabIndex = 1;
-            // 
-            // labelRandomSeed
-            // 
-            this.labelRandomSeed.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelRandomSeed.AutoSize = true;
-            this.labelRandomSeed.Location = new System.Drawing.Point(418, 102);
-            this.labelRandomSeed.Name = "labelRandomSeed";
-            this.labelRandomSeed.Size = new System.Drawing.Size(115, 13);
-            this.labelRandomSeed.TabIndex = 15;
-            this.labelRandomSeed.Text = "Random Number Seed";
-            // 
-            // textBoxLastAge
-            // 
-            this.textBoxLastAge.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.textBoxLastAge.Location = new System.Drawing.Point(217, 98);
-            this.textBoxLastAge.MinimumSize = new System.Drawing.Size(120, 20);
-            this.textBoxLastAge.Name = "textBoxLastAge";
-            this.textBoxLastAge.Size = new System.Drawing.Size(120, 20);
-            this.textBoxLastAge.TabIndex = 7;
-            // 
-            // labelNumFleets
-            // 
-            this.labelNumFleets.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelNumFleets.AutoSize = true;
-            this.labelNumFleets.Location = new System.Drawing.Point(418, 9);
-            this.labelNumFleets.Name = "labelNumFleets";
-            this.labelNumFleets.Size = new System.Drawing.Size(89, 13);
-            this.labelNumFleets.TabIndex = 9;
-            this.labelNumFleets.Text = "Number Of Fleets";
-            // 
-            // textBoxNumFleets
-            // 
-            this.textBoxNumFleets.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.textBoxNumFleets.Location = new System.Drawing.Point(584, 5);
-            this.textBoxNumFleets.MinimumSize = new System.Drawing.Size(120, 20);
-            this.textBoxNumFleets.Name = "textBoxNumFleets";
-            this.textBoxNumFleets.Size = new System.Drawing.Size(120, 20);
-            this.textBoxNumFleets.TabIndex = 10;
-            this.textBoxNumFleets.Text = "1";
-            // 
-            // labelLastAge
-            // 
-            this.labelLastAge.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelLastAge.AutoSize = true;
-            this.labelLastAge.Location = new System.Drawing.Point(81, 102);
-            this.labelLastAge.Name = "labelLastAge";
-            this.labelLastAge.Size = new System.Drawing.Size(77, 13);
-            this.labelLastAge.TabIndex = 6;
-            this.labelLastAge.Text = "Last Age Class";
-            // 
-            // labelNumPopSim
-            // 
-            this.labelNumPopSim.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelNumPopSim.AutoSize = true;
-            this.labelNumPopSim.Location = new System.Drawing.Point(418, 64);
-            this.labelNumPopSim.Name = "labelNumPopSim";
-            this.labelNumPopSim.Size = new System.Drawing.Size(112, 26);
-            this.labelNumPopSim.TabIndex = 13;
-            this.labelNumPopSim.Text = "Number of Population Simulations";
-            // 
-            // labelNumRecruitModels
-            // 
-            this.labelNumRecruitModels.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelNumRecruitModels.AutoSize = true;
-            this.labelNumRecruitModels.Location = new System.Drawing.Point(418, 40);
-            this.labelNumRecruitModels.Name = "labelNumRecruitModels";
-            this.labelNumRecruitModels.Size = new System.Drawing.Size(155, 13);
-            this.labelNumRecruitModels.TabIndex = 11;
-            this.labelNumRecruitModels.Text = "Number Of Recruitment Models";
-            // 
-            // textBoxNumPopSim
-            // 
-            this.textBoxNumPopSim.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.textBoxNumPopSim.Location = new System.Drawing.Point(584, 67);
-            this.textBoxNumPopSim.MinimumSize = new System.Drawing.Size(120, 20);
-            this.textBoxNumPopSim.Name = "textBoxNumPopSim";
-            this.textBoxNumPopSim.Size = new System.Drawing.Size(120, 20);
-            this.textBoxNumPopSim.TabIndex = 14;
-            // 
-            // textBoxLastYearProjection
-            // 
-            this.textBoxLastYearProjection.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.textBoxLastYearProjection.Location = new System.Drawing.Point(217, 36);
-            this.textBoxLastYearProjection.MinimumSize = new System.Drawing.Size(120, 20);
-            this.textBoxLastYearProjection.Name = "textBoxLastYearProjection";
-            this.textBoxLastYearProjection.Size = new System.Drawing.Size(120, 20);
-            this.textBoxLastYearProjection.TabIndex = 3;
-            // 
-            // labelFirstAge
-            // 
-            this.labelFirstAge.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelFirstAge.AutoSize = true;
-            this.labelFirstAge.Location = new System.Drawing.Point(81, 71);
-            this.labelFirstAge.Name = "labelFirstAge";
-            this.labelFirstAge.Size = new System.Drawing.Size(76, 13);
-            this.labelFirstAge.TabIndex = 4;
-            this.labelFirstAge.Text = "First Age Class";
-            // 
-            // labelLastYearProjection
-            // 
-            this.labelLastYearProjection.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelLastYearProjection.AutoSize = true;
-            this.labelLastYearProjection.Location = new System.Drawing.Point(81, 40);
-            this.labelLastYearProjection.Name = "labelLastYearProjection";
-            this.labelLastYearProjection.Size = new System.Drawing.Size(114, 13);
-            this.labelLastYearProjection.TabIndex = 2;
-            this.labelLastYearProjection.Text = "Last Year In Projection";
-            // 
-            // labelModelID
-            // 
-            this.labelModelID.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelModelID.AutoSize = true;
-            this.labelModelID.Location = new System.Drawing.Point(82, 173);
-            this.labelModelID.Name = "labelModelID";
-            this.labelModelID.Size = new System.Drawing.Size(50, 13);
-            this.labelModelID.TabIndex = 0;
-            this.labelModelID.Text = "Model ID";
-            // 
-            // labelInputFile
-            // 
-            this.labelInputFile.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.labelInputFile.AutoSize = true;
-            this.labelInputFile.Location = new System.Drawing.Point(82, 215);
-            this.labelInputFile.Name = "labelInputFile";
-            this.labelInputFile.Size = new System.Drawing.Size(50, 13);
-            this.labelInputFile.TabIndex = 2;
-            this.labelInputFile.Text = "Input File";
-            // 
-            // textBoxModelID
-            // 
-            this.textBoxModelID.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxModelID.Location = new System.Drawing.Point(154, 170);
-            this.textBoxModelID.Name = "textBoxModelID";
-            this.textBoxModelID.Size = new System.Drawing.Size(658, 20);
-            this.textBoxModelID.TabIndex = 1;
-            // 
-            // textBoxInputFile
-            // 
-            this.textBoxInputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBoxInputFile.Location = new System.Drawing.Point(154, 212);
-            this.textBoxInputFile.Name = "textBoxInputFile";
-            this.textBoxInputFile.ReadOnly = true;
-            this.textBoxInputFile.Size = new System.Drawing.Size(658, 20);
-            this.textBoxInputFile.TabIndex = 3;
-            // 
-            // ControlGeneral
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.textBoxInputFile);
-            this.Controls.Add(this.textBoxModelID);
-            this.Controls.Add(this.labelInputFile);
-            this.Controls.Add(this.labelModelID);
-            this.Controls.Add(this.groupGeneralOptions);
-            this.MinimumSize = new System.Drawing.Size(900, 520);
-            this.Name = "ControlGeneral";
-            this.Size = new System.Drawing.Size(900, 520);
-            this.groupGeneralOptions.ResumeLayout(false);
-            this.tableLayoutPanelGeneralOptions.ResumeLayout(false);
-            this.tableLayoutPanelGeneralOptions.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.spinBoxFirstAge)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+      // 
+      // checkBoxDiscards
+      // 
+      this.checkBoxDiscards.AccessibleDescription = "";
+      this.checkBoxDiscards.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.checkBoxDiscards.AutoSize = true;
+      this.checkBoxDiscards.Location = new System.Drawing.Point(81, 132);
+      this.checkBoxDiscards.MinimumSize = new System.Drawing.Size(127, 17);
+      this.checkBoxDiscards.Name = "checkBoxDiscards";
+      this.checkBoxDiscards.Size = new System.Drawing.Size(127, 17);
+      this.checkBoxDiscards.TabIndex = 8;
+      this.checkBoxDiscards.Text = "Discards are Present";
+      this.checkBoxDiscards.UseVisualStyleBackColor = true;
+      // 
+      // textBoxNumRecruitModels
+      // 
+      this.textBoxNumRecruitModels.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.textBoxNumRecruitModels.Location = new System.Drawing.Point(584, 36);
+      this.textBoxNumRecruitModels.MinimumSize = new System.Drawing.Size(120, 20);
+      this.textBoxNumRecruitModels.Name = "textBoxNumRecruitModels";
+      this.textBoxNumRecruitModels.Size = new System.Drawing.Size(120, 20);
+      this.textBoxNumRecruitModels.TabIndex = 12;
+      this.textBoxNumRecruitModels.Text = "1";
+      // 
+      // textBoxRandomSeed
+      // 
+      this.textBoxRandomSeed.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.textBoxRandomSeed.Location = new System.Drawing.Point(584, 98);
+      this.textBoxRandomSeed.MinimumSize = new System.Drawing.Size(120, 20);
+      this.textBoxRandomSeed.Name = "textBoxRandomSeed";
+      this.textBoxRandomSeed.Size = new System.Drawing.Size(120, 20);
+      this.textBoxRandomSeed.TabIndex = 16;
+      this.textBoxRandomSeed.Text = "0";
+      // 
+      // textBoxFirstYearProjection
+      // 
+      this.textBoxFirstYearProjection.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.textBoxFirstYearProjection.Location = new System.Drawing.Point(217, 5);
+      this.textBoxFirstYearProjection.MinimumSize = new System.Drawing.Size(120, 20);
+      this.textBoxFirstYearProjection.Name = "textBoxFirstYearProjection";
+      this.textBoxFirstYearProjection.Size = new System.Drawing.Size(120, 20);
+      this.textBoxFirstYearProjection.TabIndex = 1;
+      // 
+      // labelRandomSeed
+      // 
+      this.labelRandomSeed.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelRandomSeed.AutoSize = true;
+      this.labelRandomSeed.Location = new System.Drawing.Point(418, 102);
+      this.labelRandomSeed.Name = "labelRandomSeed";
+      this.labelRandomSeed.Size = new System.Drawing.Size(115, 13);
+      this.labelRandomSeed.TabIndex = 15;
+      this.labelRandomSeed.Text = "Random Number Seed";
+      // 
+      // textBoxLastAge
+      // 
+      this.textBoxLastAge.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.textBoxLastAge.Location = new System.Drawing.Point(217, 98);
+      this.textBoxLastAge.MinimumSize = new System.Drawing.Size(120, 20);
+      this.textBoxLastAge.Name = "textBoxLastAge";
+      this.textBoxLastAge.Size = new System.Drawing.Size(120, 20);
+      this.textBoxLastAge.TabIndex = 7;
+      // 
+      // labelNumFleets
+      // 
+      this.labelNumFleets.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelNumFleets.AutoSize = true;
+      this.labelNumFleets.Location = new System.Drawing.Point(418, 9);
+      this.labelNumFleets.Name = "labelNumFleets";
+      this.labelNumFleets.Size = new System.Drawing.Size(89, 13);
+      this.labelNumFleets.TabIndex = 9;
+      this.labelNumFleets.Text = "Number Of Fleets";
+      // 
+      // textBoxNumFleets
+      // 
+      this.textBoxNumFleets.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.textBoxNumFleets.Location = new System.Drawing.Point(584, 5);
+      this.textBoxNumFleets.MinimumSize = new System.Drawing.Size(120, 20);
+      this.textBoxNumFleets.Name = "textBoxNumFleets";
+      this.textBoxNumFleets.Size = new System.Drawing.Size(120, 20);
+      this.textBoxNumFleets.TabIndex = 10;
+      this.textBoxNumFleets.Text = "1";
+      // 
+      // labelLastAge
+      // 
+      this.labelLastAge.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelLastAge.AutoSize = true;
+      this.labelLastAge.Location = new System.Drawing.Point(81, 102);
+      this.labelLastAge.Name = "labelLastAge";
+      this.labelLastAge.Size = new System.Drawing.Size(77, 13);
+      this.labelLastAge.TabIndex = 6;
+      this.labelLastAge.Text = "Last Age Class";
+      // 
+      // labelNumPopSim
+      // 
+      this.labelNumPopSim.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelNumPopSim.AutoSize = true;
+      this.labelNumPopSim.Location = new System.Drawing.Point(418, 64);
+      this.labelNumPopSim.Name = "labelNumPopSim";
+      this.labelNumPopSim.Size = new System.Drawing.Size(112, 26);
+      this.labelNumPopSim.TabIndex = 13;
+      this.labelNumPopSim.Text = "Number of Population Simulations";
+      // 
+      // labelNumRecruitModels
+      // 
+      this.labelNumRecruitModels.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelNumRecruitModels.AutoSize = true;
+      this.labelNumRecruitModels.Location = new System.Drawing.Point(418, 40);
+      this.labelNumRecruitModels.Name = "labelNumRecruitModels";
+      this.labelNumRecruitModels.Size = new System.Drawing.Size(155, 13);
+      this.labelNumRecruitModels.TabIndex = 11;
+      this.labelNumRecruitModels.Text = "Number Of Recruitment Models";
+      // 
+      // textBoxNumPopSim
+      // 
+      this.textBoxNumPopSim.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.textBoxNumPopSim.Location = new System.Drawing.Point(584, 67);
+      this.textBoxNumPopSim.MinimumSize = new System.Drawing.Size(120, 20);
+      this.textBoxNumPopSim.Name = "textBoxNumPopSim";
+      this.textBoxNumPopSim.Size = new System.Drawing.Size(120, 20);
+      this.textBoxNumPopSim.TabIndex = 14;
+      // 
+      // textBoxLastYearProjection
+      // 
+      this.textBoxLastYearProjection.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.textBoxLastYearProjection.Location = new System.Drawing.Point(217, 36);
+      this.textBoxLastYearProjection.MinimumSize = new System.Drawing.Size(120, 20);
+      this.textBoxLastYearProjection.Name = "textBoxLastYearProjection";
+      this.textBoxLastYearProjection.Size = new System.Drawing.Size(120, 20);
+      this.textBoxLastYearProjection.TabIndex = 3;
+      // 
+      // labelFirstAge
+      // 
+      this.labelFirstAge.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelFirstAge.AutoSize = true;
+      this.labelFirstAge.Location = new System.Drawing.Point(81, 71);
+      this.labelFirstAge.Name = "labelFirstAge";
+      this.labelFirstAge.Size = new System.Drawing.Size(76, 13);
+      this.labelFirstAge.TabIndex = 4;
+      this.labelFirstAge.Text = "First Age Class";
+      // 
+      // labelLastYearProjection
+      // 
+      this.labelLastYearProjection.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelLastYearProjection.AutoSize = true;
+      this.labelLastYearProjection.Location = new System.Drawing.Point(81, 40);
+      this.labelLastYearProjection.Name = "labelLastYearProjection";
+      this.labelLastYearProjection.Size = new System.Drawing.Size(114, 13);
+      this.labelLastYearProjection.TabIndex = 2;
+      this.labelLastYearProjection.Text = "Last Year In Projection";
+      // 
+      // labelModelID
+      // 
+      this.labelModelID.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelModelID.AutoSize = true;
+      this.labelModelID.Location = new System.Drawing.Point(76, 149);
+      this.labelModelID.Name = "labelModelID";
+      this.labelModelID.Size = new System.Drawing.Size(50, 13);
+      this.labelModelID.TabIndex = 0;
+      this.labelModelID.Text = "Model ID";
+      // 
+      // labelInputFile
+      // 
+      this.labelInputFile.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelInputFile.AutoSize = true;
+      this.labelInputFile.Location = new System.Drawing.Point(76, 191);
+      this.labelInputFile.Name = "labelInputFile";
+      this.labelInputFile.Size = new System.Drawing.Size(50, 13);
+      this.labelInputFile.TabIndex = 2;
+      this.labelInputFile.Text = "Input File";
+      // 
+      // textBoxModelID
+      // 
+      this.textBoxModelID.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+      this.textBoxModelID.Location = new System.Drawing.Point(148, 146);
+      this.textBoxModelID.Name = "textBoxModelID";
+      this.textBoxModelID.Size = new System.Drawing.Size(658, 20);
+      this.textBoxModelID.TabIndex = 1;
+      // 
+      // textBoxInputFile
+      // 
+      this.textBoxInputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+      this.textBoxInputFile.Location = new System.Drawing.Point(148, 188);
+      this.textBoxInputFile.Name = "textBoxInputFile";
+      this.textBoxInputFile.ParamName = null;
+      this.textBoxInputFile.PrevValidValue = "";
+      this.textBoxInputFile.ReadOnly = true;
+      this.textBoxInputFile.Size = new System.Drawing.Size(658, 20);
+      this.textBoxInputFile.TabIndex = 3;
+      // 
+      // textBoxInpfileFormat
+      // 
+      this.textBoxInpfileFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+      this.textBoxInpfileFormat.Location = new System.Drawing.Point(148, 226);
+      this.textBoxInpfileFormat.Name = "textBoxInpfileFormat";
+      this.textBoxInpfileFormat.ParamName = null;
+      this.textBoxInpfileFormat.PrevValidValue = "";
+      this.textBoxInpfileFormat.ReadOnly = true;
+      this.textBoxInpfileFormat.Size = new System.Drawing.Size(253, 20);
+      this.textBoxInpfileFormat.TabIndex = 3;
+      // 
+      // ControlGeneral
+      // 
+      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.Controls.Add(this.textBoxInpfileFormat);
+      this.Controls.Add(this.textBoxInputFile);
+      this.Controls.Add(this.textBoxModelID);
+      this.Controls.Add(this.labelInputFile);
+      this.Controls.Add(this.labelModelID);
+      this.Controls.Add(this.groupGeneralOptions);
+      this.MinimumSize = new System.Drawing.Size(900, 520);
+      this.Name = "ControlGeneral";
+      this.Size = new System.Drawing.Size(900, 520);
+      this.groupGeneralOptions.ResumeLayout(false);
+      this.tableLayoutPanelGeneralOptions.ResumeLayout(false);
+      this.tableLayoutPanelGeneralOptions.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.spinBoxFirstAge)).EndInit();
+      this.ResumeLayout(false);
+      this.PerformLayout();
 
         }
 
@@ -384,5 +399,6 @@
         private System.Windows.Forms.TextBox textBoxNumFleets;
         private System.Windows.Forms.Label labelLastYearProjection;
         private System.Windows.Forms.TextBox textBoxLastYearProjection;
-    }
+    private NftTextBox textBoxInpfileFormat;
+  }
 }

--- a/src/ui/formAgepro/general-startup/ControlGeneral.Designer.cs
+++ b/src/ui/formAgepro/general-startup/ControlGeneral.Designer.cs
@@ -51,8 +51,9 @@
       this.labelModelID = new System.Windows.Forms.Label();
       this.labelInputFile = new System.Windows.Forms.Label();
       this.textBoxModelID = new System.Windows.Forms.TextBox();
-      this.textBoxInputFile = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelInpflieFormat = new System.Windows.Forms.Label();
       this.textBoxInpfileFormat = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxInputFile = new Nmfs.Agepro.Gui.NftTextBox();
       this.groupGeneralOptions.SuspendLayout();
       this.tableLayoutPanelGeneralOptions.SuspendLayout();
       ((System.ComponentModel.ISupportInitialize)(this.spinBoxFirstAge)).BeginInit();
@@ -305,7 +306,7 @@
       // 
       this.labelModelID.Anchor = System.Windows.Forms.AnchorStyles.Left;
       this.labelModelID.AutoSize = true;
-      this.labelModelID.Location = new System.Drawing.Point(76, 149);
+      this.labelModelID.Location = new System.Drawing.Point(73, 130);
       this.labelModelID.Name = "labelModelID";
       this.labelModelID.Size = new System.Drawing.Size(50, 13);
       this.labelModelID.TabIndex = 0;
@@ -315,7 +316,7 @@
       // 
       this.labelInputFile.Anchor = System.Windows.Forms.AnchorStyles.Left;
       this.labelInputFile.AutoSize = true;
-      this.labelInputFile.Location = new System.Drawing.Point(76, 191);
+      this.labelInputFile.Location = new System.Drawing.Point(73, 172);
       this.labelInputFile.Name = "labelInputFile";
       this.labelInputFile.Size = new System.Drawing.Size(50, 13);
       this.labelInputFile.TabIndex = 2;
@@ -324,15 +325,36 @@
       // textBoxModelID
       // 
       this.textBoxModelID.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-      this.textBoxModelID.Location = new System.Drawing.Point(148, 146);
+      this.textBoxModelID.Location = new System.Drawing.Point(145, 127);
       this.textBoxModelID.Name = "textBoxModelID";
       this.textBoxModelID.Size = new System.Drawing.Size(658, 20);
       this.textBoxModelID.TabIndex = 1;
       // 
+      // labelInpflieFormat
+      // 
+      this.labelInpflieFormat.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.labelInpflieFormat.AutoSize = true;
+      this.labelInpflieFormat.Location = new System.Drawing.Point(73, 215);
+      this.labelInpflieFormat.Name = "labelInpflieFormat";
+      this.labelInpflieFormat.Size = new System.Drawing.Size(123, 13);
+      this.labelInpflieFormat.TabIndex = 6;
+      this.labelInpflieFormat.Text = "Input File Version Format";
+      // 
+      // textBoxInpfileFormat
+      // 
+      this.textBoxInpfileFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+      this.textBoxInpfileFormat.Location = new System.Drawing.Point(219, 212);
+      this.textBoxInpfileFormat.Name = "textBoxInpfileFormat";
+      this.textBoxInpfileFormat.ParamName = null;
+      this.textBoxInpfileFormat.PrevValidValue = "";
+      this.textBoxInpfileFormat.ReadOnly = true;
+      this.textBoxInpfileFormat.Size = new System.Drawing.Size(182, 20);
+      this.textBoxInpfileFormat.TabIndex = 3;
+      // 
       // textBoxInputFile
       // 
       this.textBoxInputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-      this.textBoxInputFile.Location = new System.Drawing.Point(148, 188);
+      this.textBoxInputFile.Location = new System.Drawing.Point(145, 169);
       this.textBoxInputFile.Name = "textBoxInputFile";
       this.textBoxInputFile.ParamName = null;
       this.textBoxInputFile.PrevValidValue = "";
@@ -340,21 +362,11 @@
       this.textBoxInputFile.Size = new System.Drawing.Size(658, 20);
       this.textBoxInputFile.TabIndex = 3;
       // 
-      // textBoxInpfileFormat
-      // 
-      this.textBoxInpfileFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
-      this.textBoxInpfileFormat.Location = new System.Drawing.Point(148, 226);
-      this.textBoxInpfileFormat.Name = "textBoxInpfileFormat";
-      this.textBoxInpfileFormat.ParamName = null;
-      this.textBoxInpfileFormat.PrevValidValue = "";
-      this.textBoxInpfileFormat.ReadOnly = true;
-      this.textBoxInpfileFormat.Size = new System.Drawing.Size(253, 20);
-      this.textBoxInpfileFormat.TabIndex = 3;
-      // 
       // ControlGeneral
       // 
       this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
       this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.Controls.Add(this.labelInpflieFormat);
       this.Controls.Add(this.textBoxInpfileFormat);
       this.Controls.Add(this.textBoxInputFile);
       this.Controls.Add(this.textBoxModelID);
@@ -400,5 +412,6 @@
         private System.Windows.Forms.Label labelLastYearProjection;
         private System.Windows.Forms.TextBox textBoxLastYearProjection;
     private NftTextBox textBoxInpfileFormat;
+    private System.Windows.Forms.Label labelInpflieFormat;
   }
 }

--- a/src/ui/formAgepro/general-startup/ControlGeneral.cs
+++ b/src/ui/formAgepro/general-startup/ControlGeneral.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Nmfs.Agepro.CoreLib;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
@@ -68,6 +69,12 @@ namespace Nmfs.Agepro.Gui
       set => checkBoxDiscards.Checked = value;
     }
 
+    public string GeneralInpfileFormatTextBoxString
+    {
+      get => textBoxInpfileFormat.Text;
+      set => textBoxInpfileFormat.Text = value;
+    }
+
     public ControlGeneral()
     {
       InitializeComponent();
@@ -80,12 +87,31 @@ namespace Nmfs.Agepro.Gui
 
     }
 
+
+    #region Version Textbox DataBindings
+    /// <summary>
+    /// Intializes the control's values and data bindings to the Version Textbox  object
+    /// </summary>
+    /// <param name="inpfileVer">AGEPRO CoreLib Bootstrap object</param>
+    public void SetupInpfileFormatTextBoxDataBindings(CoreLib.AgeproInputFile inpData)
+    {
+
+      //Clear any existing bindings before creating new ones.
+      textBoxInpfileFormat.DataBindings.Clear();
+
+      //Data Binding
+      _ = textBoxInpfileFormat.DataBindings.Add("Text", inpData, nameof(CoreLib.AgeproInputFile.Version),
+                                                formattingEnabled: true, DataSourceUpdateMode.OnPropertyChanged);
+    }
+
+    #endregion
+
     /// <summary>
     /// 
     /// </summary>
     public void ValidateGeneralOptionsParameters()
     {
-
+      //This is used for prompts
       Dictionary<string, string> generalOptionsList = new Dictionary<string, string> {
         {"First Year Of Projection", textBoxFirstYearProjection.Text},
         {"Last Year Of Projection", textBoxLastYearProjection.Text},

--- a/src/ui/formAgepro/harvestScenario/ControlHarvestScenario.cs
+++ b/src/ui/formAgepro/harvestScenario/ControlHarvestScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data;
+using System.Linq;
 using System.Windows.Forms;
 using Nmfs.Agepro.CoreLib;
 
@@ -199,8 +200,14 @@ namespace Nmfs.Agepro.Gui
     /// Data Validation. 
     /// </summary>
     /// <returns></returns>
-    public bool ValidateHarvestScenario(int[] ObsYears)
+    public bool ValidateHarvestScenario(ControlGeneral controlGeneral)
     {
+      //ObsYears
+      int[] ObsYears = controlGeneral.SeqYears()
+                                     .Where(s => int.TryParse(s, out _))
+                                     .Select(int.Parse)
+                                     .ToArray();
+
       if (dataGridHarvestScenarioTable.HasBlankOrNullCells())
       {
         _ = MessageBox.Show("Harvest Scenario Data Table has blank or missing values.", "Harvest Scenario",

--- a/src/ui/formAgepro/harvestScenario/ControlHarvestScenario.cs
+++ b/src/ui/formAgepro/harvestScenario/ControlHarvestScenario.cs
@@ -199,7 +199,7 @@ namespace Nmfs.Agepro.Gui
     /// Data Validation. 
     /// </summary>
     /// <returns></returns>
-    public bool ValidateHarvestScenario()
+    public bool ValidateHarvestScenario(int[] ObsYears)
     {
       if (dataGridHarvestScenarioTable.HasBlankOrNullCells())
       {
@@ -210,6 +210,7 @@ namespace Nmfs.Agepro.Gui
 
       if (radioRebuilderTarget.Checked)
       {
+        Rebuilder.ObsYears = ObsYears;
         ValidationResult rebuilderCheck = Rebuilder.ValidationCheck();
 
         if (rebuilderCheck.IsValid == false)
@@ -223,6 +224,7 @@ namespace Nmfs.Agepro.Gui
       }
       else if (radioPStar.Checked)
       {
+        PStar.ObsYears = ObsYears;
         ValidationResult pstarCheck = PStar.ValidationCheck();
         if (pstarCheck.IsValid == false)
         {

--- a/src/ui/formAgepro/harvestScenario/ControlHarvestScenario.cs
+++ b/src/ui/formAgepro/harvestScenario/ControlHarvestScenario.cs
@@ -62,12 +62,13 @@ namespace Nmfs.Agepro.Gui
       {
         if (PStar == null)
         {
+          //Create new instance of PStar with AGEPRO Model's Observed Years
           PStar = new PStarCalculation
           {
-            //Retain Model's Observed Years
             ObsYears = Array.ConvertAll(SeqYears, int.Parse)
           };
         }
+        CalcType = HarvestScenarioAnalysis.PStar;
         ControlHarvestPStar.SetHarvestCalcPStarControls(PStar, panelAltCalcParameters);
       }
 
@@ -89,7 +90,7 @@ namespace Nmfs.Agepro.Gui
       {
         if (Rebuilder == null)
         {
-          //Retain Model's Observed Years
+          //Create new instance of Rebuilder with AGEPRO Model's Observed Years
           Rebuilder = new RebuilderTargetCalculation
           {
             ObsYears = Array.ConvertAll(SeqYears, int.Parse)

--- a/src/ui/formAgepro/io/AgeproCalculationLauncher.cs
+++ b/src/ui/formAgepro/io/AgeproCalculationLauncher.cs
@@ -161,7 +161,7 @@ namespace Nmfs.Agepro.Gui
         //crude method to create AGEPRO Calcuation Engine output file
         string ageproOutfile = Path.ChangeExtension(inpFile,".out");
 
-        LaunchOutputViewerProgram(outFilePath, AgeproUserOptions);
+        LaunchOutputViewerProgram(ageproOutfile, AgeproUserOptions);
 
         //Open WorkPath directory for the user 
         _ = Process.Start(ageproWorkPath);

--- a/src/ui/formAgepro/io/AgeproCalculationLauncher.cs
+++ b/src/ui/formAgepro/io/AgeproCalculationLauncher.cs
@@ -146,6 +146,8 @@ namespace Nmfs.Agepro.Gui
 
       try
       {
+        //TODO:Split TryCatch to accomdate (pre) launch AGEPRO and (post) output proccessing errors.
+
         //Set bootstrap filename to copied workDir version
         ageproData.Bootstrap.BootstrapFile = bsnFile;
 
@@ -155,17 +157,30 @@ namespace Nmfs.Agepro.Gui
         //use command line to open AGEPRO40.exe
         LaunchAgeproCalcEngineProgram(inpFile);
 
-        //crude method to search for AGEPRO output file
-        string ageproOutfile = Directory.GetFiles(Path.GetDirectoryName(inpFile), "*.out").First();
+        //crude method to search for AGEPRO output file 
+        Console.WriteLine("Getting path of: " + inpFile);
+        string targetOutputPath = Path.GetDirectoryName(inpFile);
+        Console.WriteLine(Directory.GetFiles(targetOutputPath, ".out").Length);
+      
+        if (Directory.GetFiles(targetOutputPath, ".out").Length == 0)
+        {
+          throw new Exception("No AGEPRO output file (*.out) found on target output path: " + Environment.NewLine 
+            + targetOutputPath + Environment.NewLine);
+          
+        }
+        string outFilePath = Directory.EnumerateFiles(targetOutputPath, "*.out").First();
+        Console.WriteLine("Viewing " + outFilePath);
+        //string ageproOutfile = Directory.GetFiles(Path.GetDirectoryName(inpFile), "*.out").First();
 
-        LaunchOutputViewerProgram(ageproOutfile, AgeproUserOptions);
+        LaunchOutputViewerProgram(outFilePath, AgeproUserOptions);
 
         //Open WorkPath directory for the user 
         _ = Process.Start(ageproWorkPath);
       }
       catch (Exception ex)
       {
-        _ = MessageBox.Show("An error occured when Launching the AGEPRO Model." + Environment.NewLine + ex, "", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        _ = MessageBox.Show("An error occured when processing AGEPRO Model to the Calcuation Engine:" + Environment.NewLine 
+          + Environment.NewLine + ex.Message, "", MessageBoxButtons.OK, MessageBoxIcon.Error);
       }
       finally
       {

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -35,22 +35,32 @@
       this.checkBoxEnableExportR = new System.Windows.Forms.CheckBox();
       this.checkBoxEnableAuxStochasticFiles = new System.Windows.Forms.CheckBox();
       this.groupRefpoints = new System.Windows.Forms.GroupBox();
+      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelFishMortality = new System.Windows.Forms.Label();
+      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.checkBoxEnableRefpoints = new System.Windows.Forms.CheckBox();
       this.labelMeanBiomass = new System.Windows.Forms.Label();
+      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelJan1Biomass = new System.Windows.Forms.Label();
+      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelSpawnBiomass = new System.Windows.Forms.Label();
       this.groupBounds = new System.Windows.Forms.GroupBox();
+      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsNatMortality = new System.Windows.Forms.Label();
+      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsMaxWeight = new System.Windows.Forms.Label();
       this.checkBoxBounds = new System.Windows.Forms.CheckBox();
       this.groupScaleFactors = new System.Windows.Forms.GroupBox();
+      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorRecruits = new System.Windows.Forms.Label();
+      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorStockNum = new System.Windows.Forms.Label();
+      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorBiomass = new System.Windows.Forms.Label();
       this.checkBoxEnableScaleFactors = new System.Windows.Forms.CheckBox();
       this.groupRetroAdjustment = new System.Windows.Forms.GroupBox();
       this.checkBoxEnableRetroAdjustment = new System.Windows.Forms.CheckBox();
+      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
       this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
@@ -60,26 +70,16 @@
       this.radioButtonStockAge_AllAux = new System.Windows.Forms.RadioButton();
       this.radioButtonNoStockAge_ExcludeStockNumAux = new System.Windows.Forms.RadioButton();
       this.groupOutputViewer = new System.Windows.Forms.GroupBox();
-      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
-      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
-      this.checkBoxVer40Format = new System.Windows.Forms.CheckBox();
+      this.checkBoxEnableVer40Format = new System.Windows.Forms.CheckBox();
       this.groupOuputOptions.SuspendLayout();
       ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).BeginInit();
       this.groupRefpoints.SuspendLayout();
       this.groupBounds.SuspendLayout();
       this.groupScaleFactors.SuspendLayout();
       this.groupRetroAdjustment.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.groupBox_StockSummmaryFlag.SuspendLayout();
       this.groupOutputViewer.SuspendLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.SuspendLayout();
       // 
       // groupOuputOptions
@@ -89,9 +89,11 @@
       this.groupOuputOptions.Controls.Add(this.checkBoxEnablePercentileReport);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableExportR);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableAuxStochasticFiles);
-      this.groupOuputOptions.Location = new System.Drawing.Point(29, 154);
+      this.groupOuputOptions.Location = new System.Drawing.Point(39, 190);
+      this.groupOuputOptions.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.groupOuputOptions.Name = "groupOuputOptions";
-      this.groupOuputOptions.Size = new System.Drawing.Size(406, 123);
+      this.groupOuputOptions.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupOuputOptions.Size = new System.Drawing.Size(541, 151);
       this.groupOuputOptions.TabIndex = 1;
       this.groupOuputOptions.TabStop = false;
       this.groupOuputOptions.Text = "Output Options";
@@ -100,27 +102,30 @@
       // 
       this.spinBoxReportPercentile.DecimalPlaces = 1;
       this.spinBoxReportPercentile.Enabled = false;
-      this.spinBoxReportPercentile.Location = new System.Drawing.Point(159, 88);
+      this.spinBoxReportPercentile.Location = new System.Drawing.Point(212, 108);
+      this.spinBoxReportPercentile.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.spinBoxReportPercentile.Name = "spinBoxReportPercentile";
-      this.spinBoxReportPercentile.Size = new System.Drawing.Size(107, 20);
+      this.spinBoxReportPercentile.Size = new System.Drawing.Size(143, 22);
       this.spinBoxReportPercentile.TabIndex = 5;
       // 
       // labelReportPercentile
       // 
       this.labelReportPercentile.AutoSize = true;
       this.labelReportPercentile.Enabled = false;
-      this.labelReportPercentile.Location = new System.Drawing.Point(64, 90);
+      this.labelReportPercentile.Location = new System.Drawing.Point(85, 111);
+      this.labelReportPercentile.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelReportPercentile.Name = "labelReportPercentile";
-      this.labelReportPercentile.Size = new System.Drawing.Size(89, 13);
+      this.labelReportPercentile.Size = new System.Drawing.Size(111, 16);
       this.labelReportPercentile.TabIndex = 4;
       this.labelReportPercentile.Text = "Report Percentile";
       // 
       // checkBoxEnablePercentileReport
       // 
       this.checkBoxEnablePercentileReport.AutoSize = true;
-      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(17, 66);
+      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(23, 81);
+      this.checkBoxEnablePercentileReport.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.checkBoxEnablePercentileReport.Name = "checkBoxEnablePercentileReport";
-      this.checkBoxEnablePercentileReport.Size = new System.Drawing.Size(151, 17);
+      this.checkBoxEnablePercentileReport.Size = new System.Drawing.Size(187, 20);
       this.checkBoxEnablePercentileReport.TabIndex = 3;
       this.checkBoxEnablePercentileReport.Text = "Request Percentile Report";
       this.checkBoxEnablePercentileReport.UseVisualStyleBackColor = true;
@@ -129,9 +134,10 @@
       // checkBoxEnableExportR
       // 
       this.checkBoxEnableExportR.AutoSize = true;
-      this.checkBoxEnableExportR.Location = new System.Drawing.Point(17, 43);
+      this.checkBoxEnableExportR.Location = new System.Drawing.Point(23, 53);
+      this.checkBoxEnableExportR.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.checkBoxEnableExportR.Name = "checkBoxEnableExportR";
-      this.checkBoxEnableExportR.Size = new System.Drawing.Size(117, 17);
+      this.checkBoxEnableExportR.Size = new System.Drawing.Size(142, 20);
       this.checkBoxEnableExportR.TabIndex = 2;
       this.checkBoxEnableExportR.Text = "Export Results to R";
       this.checkBoxEnableExportR.UseVisualStyleBackColor = true;
@@ -139,9 +145,10 @@
       // checkBoxEnableAuxStochasticFiles
       // 
       this.checkBoxEnableAuxStochasticFiles.AutoSize = true;
-      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(17, 20);
+      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(23, 25);
+      this.checkBoxEnableAuxStochasticFiles.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.checkBoxEnableAuxStochasticFiles.Name = "checkBoxEnableAuxStochasticFiles";
-      this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(214, 17);
+      this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(267, 20);
       this.checkBoxEnableAuxStochasticFiles.TabIndex = 4;
       this.checkBoxEnableAuxStochasticFiles.Text = "Generate Auxiliary Stochastic Data Files";
       this.checkBoxEnableAuxStochasticFiles.UseVisualStyleBackColor = true;
@@ -157,29 +164,55 @@
       this.groupRefpoints.Controls.Add(this.labelJan1Biomass);
       this.groupRefpoints.Controls.Add(this.textBoxRefSpawnBiomass);
       this.groupRefpoints.Controls.Add(this.labelSpawnBiomass);
-      this.groupRefpoints.Location = new System.Drawing.Point(441, 219);
+      this.groupRefpoints.Location = new System.Drawing.Point(588, 270);
+      this.groupRefpoints.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.groupRefpoints.Name = "groupRefpoints";
-      this.groupRefpoints.Size = new System.Drawing.Size(390, 152);
+      this.groupRefpoints.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupRefpoints.Size = new System.Drawing.Size(520, 187);
       this.groupRefpoints.TabIndex = 5;
       this.groupRefpoints.TabStop = false;
       this.groupRefpoints.Text = "Reference Points";
+      // 
+      // textBoxRefFishMortality
+      // 
+      this.textBoxRefFishMortality.Enabled = false;
+      this.textBoxRefFishMortality.Location = new System.Drawing.Point(252, 148);
+      this.textBoxRefFishMortality.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
+      this.textBoxRefFishMortality.ParamName = null;
+      this.textBoxRefFishMortality.PrevValidValue = "";
+      this.textBoxRefFishMortality.Size = new System.Drawing.Size(155, 22);
+      this.textBoxRefFishMortality.TabIndex = 8;
       // 
       // labelFishMortality
       // 
       this.labelFishMortality.AutoSize = true;
       this.labelFishMortality.Enabled = false;
-      this.labelFishMortality.Location = new System.Drawing.Point(19, 123);
+      this.labelFishMortality.Location = new System.Drawing.Point(25, 151);
+      this.labelFishMortality.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelFishMortality.Name = "labelFishMortality";
-      this.labelFishMortality.Size = new System.Drawing.Size(82, 13);
+      this.labelFishMortality.Size = new System.Drawing.Size(103, 16);
       this.labelFishMortality.TabIndex = 7;
       this.labelFishMortality.Text = "Fishing Mortality";
+      // 
+      // textBoxRefMeanBiomass
+      // 
+      this.textBoxRefMeanBiomass.Enabled = false;
+      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(252, 116);
+      this.textBoxRefMeanBiomass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
+      this.textBoxRefMeanBiomass.ParamName = null;
+      this.textBoxRefMeanBiomass.PrevValidValue = "";
+      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(155, 22);
+      this.textBoxRefMeanBiomass.TabIndex = 6;
       // 
       // checkBoxEnableRefpoints
       // 
       this.checkBoxEnableRefpoints.AutoSize = true;
-      this.checkBoxEnableRefpoints.Location = new System.Drawing.Point(22, 19);
+      this.checkBoxEnableRefpoints.Location = new System.Drawing.Point(29, 23);
+      this.checkBoxEnableRefpoints.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.checkBoxEnableRefpoints.Name = "checkBoxEnableRefpoints";
-      this.checkBoxEnableRefpoints.Size = new System.Drawing.Size(224, 17);
+      this.checkBoxEnableRefpoints.Size = new System.Drawing.Size(279, 20);
       this.checkBoxEnableRefpoints.TabIndex = 0;
       this.checkBoxEnableRefpoints.Text = "Enable Reference Point Threshold Report";
       this.checkBoxEnableRefpoints.UseVisualStyleBackColor = true;
@@ -189,29 +222,54 @@
       // 
       this.labelMeanBiomass.AutoSize = true;
       this.labelMeanBiomass.Enabled = false;
-      this.labelMeanBiomass.Location = new System.Drawing.Point(19, 97);
+      this.labelMeanBiomass.Location = new System.Drawing.Point(25, 119);
+      this.labelMeanBiomass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelMeanBiomass.Name = "labelMeanBiomass";
-      this.labelMeanBiomass.Size = new System.Drawing.Size(101, 13);
+      this.labelMeanBiomass.Size = new System.Drawing.Size(128, 16);
       this.labelMeanBiomass.TabIndex = 5;
       this.labelMeanBiomass.Text = "Mean Biomass (MT)";
+      // 
+      // textBoxRefJan1Biomass
+      // 
+      this.textBoxRefJan1Biomass.Enabled = false;
+      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(252, 84);
+      this.textBoxRefJan1Biomass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
+      this.textBoxRefJan1Biomass.ParamName = null;
+      this.textBoxRefJan1Biomass.PrevValidValue = "";
+      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(155, 22);
+      this.textBoxRefJan1Biomass.TabIndex = 4;
       // 
       // labelJan1Biomass
       // 
       this.labelJan1Biomass.AutoSize = true;
       this.labelJan1Biomass.Enabled = false;
-      this.labelJan1Biomass.Location = new System.Drawing.Point(19, 71);
+      this.labelJan1Biomass.Location = new System.Drawing.Point(25, 87);
+      this.labelJan1Biomass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelJan1Biomass.Name = "labelJan1Biomass";
-      this.labelJan1Biomass.Size = new System.Drawing.Size(131, 13);
+      this.labelJan1Biomass.Size = new System.Drawing.Size(164, 16);
       this.labelJan1Biomass.TabIndex = 3;
       this.labelJan1Biomass.Text = "Jan-1 Stock Biomass (MT)";
+      // 
+      // textBoxRefSpawnBiomass
+      // 
+      this.textBoxRefSpawnBiomass.Enabled = false;
+      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(252, 52);
+      this.textBoxRefSpawnBiomass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
+      this.textBoxRefSpawnBiomass.ParamName = null;
+      this.textBoxRefSpawnBiomass.PrevValidValue = "";
+      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(155, 22);
+      this.textBoxRefSpawnBiomass.TabIndex = 2;
       // 
       // labelSpawnBiomass
       // 
       this.labelSpawnBiomass.AutoSize = true;
       this.labelSpawnBiomass.Enabled = false;
-      this.labelSpawnBiomass.Location = new System.Drawing.Point(19, 45);
+      this.labelSpawnBiomass.Location = new System.Drawing.Point(25, 55);
+      this.labelSpawnBiomass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelSpawnBiomass.Name = "labelSpawnBiomass";
-      this.labelSpawnBiomass.Size = new System.Drawing.Size(152, 13);
+      this.labelSpawnBiomass.Size = new System.Drawing.Size(190, 16);
       this.labelSpawnBiomass.TabIndex = 1;
       this.labelSpawnBiomass.Text = "Spawning Stock Biomass (MT)";
       // 
@@ -222,39 +280,68 @@
       this.groupBounds.Controls.Add(this.textBoxBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.labelBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.checkBoxBounds);
-      this.groupBounds.Location = new System.Drawing.Point(441, 114);
+      this.groupBounds.Location = new System.Drawing.Point(588, 140);
+      this.groupBounds.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.groupBounds.Name = "groupBounds";
-      this.groupBounds.Size = new System.Drawing.Size(390, 99);
+      this.groupBounds.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupBounds.Size = new System.Drawing.Size(520, 122);
       this.groupBounds.TabIndex = 4;
       this.groupBounds.TabStop = false;
       this.groupBounds.Text = "Bounds";
+      // 
+      // textBoxBoundsNatMortality
+      // 
+      this.textBoxBoundsNatMortality.Enabled = false;
+      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(211, 84);
+      this.textBoxBoundsNatMortality.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
+      this.textBoxBoundsNatMortality.ParamName = null;
+      this.textBoxBoundsNatMortality.PrevValidValue = "";
+      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(132, 22);
+      this.textBoxBoundsNatMortality.TabIndex = 4;
+      this.textBoxBoundsNatMortality.Text = "1.0";
       // 
       // labelBoundsNatMortality
       // 
       this.labelBoundsNatMortality.AutoSize = true;
       this.labelBoundsNatMortality.Enabled = false;
-      this.labelBoundsNatMortality.Location = new System.Drawing.Point(15, 71);
+      this.labelBoundsNatMortality.Location = new System.Drawing.Point(20, 87);
+      this.labelBoundsNatMortality.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelBoundsNatMortality.Name = "labelBoundsNatMortality";
-      this.labelBoundsNatMortality.Size = new System.Drawing.Size(130, 13);
+      this.labelBoundsNatMortality.Size = new System.Drawing.Size(163, 16);
       this.labelBoundsNatMortality.TabIndex = 3;
       this.labelBoundsNatMortality.Text = "Maximum Natural Mortality";
+      // 
+      // textBoxBoundsMaxWeight
+      // 
+      this.textBoxBoundsMaxWeight.Enabled = false;
+      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(211, 52);
+      this.textBoxBoundsMaxWeight.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
+      this.textBoxBoundsMaxWeight.ParamName = null;
+      this.textBoxBoundsMaxWeight.PrevValidValue = "";
+      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(132, 22);
+      this.textBoxBoundsMaxWeight.TabIndex = 2;
+      this.textBoxBoundsMaxWeight.Text = "10.0";
       // 
       // labelBoundsMaxWeight
       // 
       this.labelBoundsMaxWeight.AutoSize = true;
       this.labelBoundsMaxWeight.Enabled = false;
-      this.labelBoundsMaxWeight.Location = new System.Drawing.Point(15, 45);
+      this.labelBoundsMaxWeight.Location = new System.Drawing.Point(20, 55);
+      this.labelBoundsMaxWeight.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelBoundsMaxWeight.Name = "labelBoundsMaxWeight";
-      this.labelBoundsMaxWeight.Size = new System.Drawing.Size(109, 13);
+      this.labelBoundsMaxWeight.Size = new System.Drawing.Size(135, 16);
       this.labelBoundsMaxWeight.TabIndex = 1;
       this.labelBoundsMaxWeight.Text = "Maximum Weight (kg)";
       // 
       // checkBoxBounds
       // 
       this.checkBoxBounds.AutoSize = true;
-      this.checkBoxBounds.Location = new System.Drawing.Point(18, 19);
+      this.checkBoxBounds.Location = new System.Drawing.Point(24, 23);
+      this.checkBoxBounds.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.checkBoxBounds.Name = "checkBoxBounds";
-      this.checkBoxBounds.Size = new System.Drawing.Size(100, 17);
+      this.checkBoxBounds.Size = new System.Drawing.Size(123, 20);
       this.checkBoxBounds.TabIndex = 0;
       this.checkBoxBounds.Text = "Specify Bounds";
       this.checkBoxBounds.UseVisualStyleBackColor = true;
@@ -269,49 +356,88 @@
       this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.labelScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.checkBoxEnableScaleFactors);
-      this.groupScaleFactors.Location = new System.Drawing.Point(441, 377);
+      this.groupScaleFactors.Location = new System.Drawing.Point(588, 464);
+      this.groupScaleFactors.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.groupScaleFactors.Name = "groupScaleFactors";
-      this.groupScaleFactors.Size = new System.Drawing.Size(390, 128);
+      this.groupScaleFactors.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupScaleFactors.Size = new System.Drawing.Size(520, 158);
       this.groupScaleFactors.TabIndex = 6;
       this.groupScaleFactors.TabStop = false;
       this.groupScaleFactors.Text = "Scaling Factors for Output Report";
+      // 
+      // textBoxScaleFactorRecruits
+      // 
+      this.textBoxScaleFactorRecruits.Enabled = false;
+      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(195, 85);
+      this.textBoxScaleFactorRecruits.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
+      this.textBoxScaleFactorRecruits.ParamName = null;
+      this.textBoxScaleFactorRecruits.PrevValidValue = "";
+      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(132, 22);
+      this.textBoxScaleFactorRecruits.TabIndex = 4;
       // 
       // labelScaleFactorRecruits
       // 
       this.labelScaleFactorRecruits.AutoSize = true;
       this.labelScaleFactorRecruits.Enabled = false;
-      this.labelScaleFactorRecruits.Location = new System.Drawing.Point(22, 72);
+      this.labelScaleFactorRecruits.Location = new System.Drawing.Point(29, 89);
+      this.labelScaleFactorRecruits.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelScaleFactorRecruits.Name = "labelScaleFactorRecruits";
-      this.labelScaleFactorRecruits.Size = new System.Drawing.Size(46, 13);
+      this.labelScaleFactorRecruits.Size = new System.Drawing.Size(56, 16);
       this.labelScaleFactorRecruits.TabIndex = 3;
       this.labelScaleFactorRecruits.Text = "Recruits";
+      // 
+      // textBoxScaleFactorsStockNum
+      // 
+      this.textBoxScaleFactorsStockNum.Enabled = false;
+      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(195, 117);
+      this.textBoxScaleFactorsStockNum.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
+      this.textBoxScaleFactorsStockNum.ParamName = null;
+      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
+      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(132, 22);
+      this.textBoxScaleFactorsStockNum.TabIndex = 6;
       // 
       // labelScaleFactorStockNum
       // 
       this.labelScaleFactorStockNum.AutoSize = true;
       this.labelScaleFactorStockNum.Enabled = false;
-      this.labelScaleFactorStockNum.Location = new System.Drawing.Point(21, 98);
+      this.labelScaleFactorStockNum.Location = new System.Drawing.Point(28, 121);
+      this.labelScaleFactorStockNum.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelScaleFactorStockNum.Name = "labelScaleFactorStockNum";
-      this.labelScaleFactorStockNum.Size = new System.Drawing.Size(80, 13);
+      this.labelScaleFactorStockNum.Size = new System.Drawing.Size(99, 16);
       this.labelScaleFactorStockNum.TabIndex = 5;
       this.labelScaleFactorStockNum.Text = "Stock Numbers";
+      // 
+      // textBoxScaleFactorBiomass
+      // 
+      this.textBoxScaleFactorBiomass.Enabled = false;
+      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(195, 53);
+      this.textBoxScaleFactorBiomass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
+      this.textBoxScaleFactorBiomass.ParamName = null;
+      this.textBoxScaleFactorBiomass.PrevValidValue = "";
+      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(132, 22);
+      this.textBoxScaleFactorBiomass.TabIndex = 2;
       // 
       // labelScaleFactorBiomass
       // 
       this.labelScaleFactorBiomass.AutoSize = true;
       this.labelScaleFactorBiomass.Enabled = false;
-      this.labelScaleFactorBiomass.Location = new System.Drawing.Point(22, 46);
+      this.labelScaleFactorBiomass.Location = new System.Drawing.Point(29, 57);
+      this.labelScaleFactorBiomass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelScaleFactorBiomass.Name = "labelScaleFactorBiomass";
-      this.labelScaleFactorBiomass.Size = new System.Drawing.Size(46, 13);
+      this.labelScaleFactorBiomass.Size = new System.Drawing.Size(60, 16);
       this.labelScaleFactorBiomass.TabIndex = 1;
       this.labelScaleFactorBiomass.Text = "Biomass";
       // 
       // checkBoxEnableScaleFactors
       // 
       this.checkBoxEnableScaleFactors.AutoSize = true;
-      this.checkBoxEnableScaleFactors.Location = new System.Drawing.Point(22, 20);
+      this.checkBoxEnableScaleFactors.Location = new System.Drawing.Point(29, 25);
+      this.checkBoxEnableScaleFactors.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.checkBoxEnableScaleFactors.Name = "checkBoxEnableScaleFactors";
-      this.checkBoxEnableScaleFactors.Size = new System.Drawing.Size(233, 17);
+      this.checkBoxEnableScaleFactors.Size = new System.Drawing.Size(288, 20);
       this.checkBoxEnableScaleFactors.TabIndex = 0;
       this.checkBoxEnableScaleFactors.Text = "Specify Scale Factors for Output Report File";
       this.checkBoxEnableScaleFactors.UseVisualStyleBackColor = true;
@@ -321,9 +447,11 @@
       // 
       this.groupRetroAdjustment.Controls.Add(this.checkBoxEnableRetroAdjustment);
       this.groupRetroAdjustment.Controls.Add(this.dataGridRetroAdjustment);
-      this.groupRetroAdjustment.Location = new System.Drawing.Point(29, 283);
+      this.groupRetroAdjustment.Location = new System.Drawing.Point(39, 348);
+      this.groupRetroAdjustment.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.groupRetroAdjustment.Name = "groupRetroAdjustment";
-      this.groupRetroAdjustment.Size = new System.Drawing.Size(406, 223);
+      this.groupRetroAdjustment.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupRetroAdjustment.Size = new System.Drawing.Size(541, 274);
       this.groupRetroAdjustment.TabIndex = 2;
       this.groupRetroAdjustment.TabStop = false;
       this.groupRetroAdjustment.Text = "Retrospective Adjustment Factors";
@@ -331,13 +459,31 @@
       // checkBoxEnableRetroAdjustment
       // 
       this.checkBoxEnableRetroAdjustment.AutoSize = true;
-      this.checkBoxEnableRetroAdjustment.Location = new System.Drawing.Point(17, 20);
+      this.checkBoxEnableRetroAdjustment.Location = new System.Drawing.Point(23, 25);
+      this.checkBoxEnableRetroAdjustment.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.checkBoxEnableRetroAdjustment.Name = "checkBoxEnableRetroAdjustment";
-      this.checkBoxEnableRetroAdjustment.Size = new System.Drawing.Size(223, 17);
+      this.checkBoxEnableRetroAdjustment.Size = new System.Drawing.Size(278, 20);
       this.checkBoxEnableRetroAdjustment.TabIndex = 1;
       this.checkBoxEnableRetroAdjustment.Text = "Specify Retrospective Adjustment Factors";
       this.checkBoxEnableRetroAdjustment.UseVisualStyleBackColor = true;
       this.checkBoxEnableRetroAdjustment.CheckedChanged += new System.EventHandler(this.CheckBoxRetroAdjustment_CheckedChanged);
+      // 
+      // dataGridRetroAdjustment
+      // 
+      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
+      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
+      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
+      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
+      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
+      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(23, 49);
+      this.dataGridRetroAdjustment.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
+      this.dataGridRetroAdjustment.nftReadOnly = false;
+      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
+      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(475, 210);
+      this.dataGridRetroAdjustment.TabIndex = 0;
+      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
       // 
       // comboBoxOutputViewerProgram
       // 
@@ -346,17 +492,19 @@
             "System Default",
             "Notepad",
             "None"});
-      this.comboBoxOutputViewerProgram.Location = new System.Drawing.Point(18, 32);
+      this.comboBoxOutputViewerProgram.Location = new System.Drawing.Point(24, 39);
+      this.comboBoxOutputViewerProgram.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.comboBoxOutputViewerProgram.Name = "comboBoxOutputViewerProgram";
-      this.comboBoxOutputViewerProgram.Size = new System.Drawing.Size(339, 21);
+      this.comboBoxOutputViewerProgram.Size = new System.Drawing.Size(451, 24);
       this.comboBoxOutputViewerProgram.TabIndex = 1;
       // 
       // labelOutputViewerProgram
       // 
       this.labelOutputViewerProgram.AutoSize = true;
-      this.labelOutputViewerProgram.Location = new System.Drawing.Point(15, 16);
+      this.labelOutputViewerProgram.Location = new System.Drawing.Point(20, 20);
+      this.labelOutputViewerProgram.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
       this.labelOutputViewerProgram.Name = "labelOutputViewerProgram";
-      this.labelOutputViewerProgram.Size = new System.Drawing.Size(189, 13);
+      this.labelOutputViewerProgram.Size = new System.Drawing.Size(234, 16);
       this.labelOutputViewerProgram.TabIndex = 0;
       this.labelOutputViewerProgram.Text = "Program to View AGEPRO Output File ";
       // 
@@ -367,9 +515,11 @@
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockAge_NoAux);
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockAge_AllAux);
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockAge_ExcludeStockNumAux);
-      this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
+      this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(39, 18);
+      this.groupBox_StockSummmaryFlag.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
-      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(406, 133);
+      this.groupBox_StockSummmaryFlag.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(541, 164);
       this.groupBox_StockSummmaryFlag.TabIndex = 0;
       this.groupBox_StockSummmaryFlag.TabStop = false;
       this.groupBox_StockSummmaryFlag.Text = "Stock Distribution Summary and Auxiliary Data Files";
@@ -377,9 +527,10 @@
       // radioButtonStockAge_ExcludeStockNumAux
       // 
       this.radioButtonStockAge_ExcludeStockNumAux.AutoSize = true;
-      this.radioButtonStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 109);
+      this.radioButtonStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(23, 134);
+      this.radioButtonStockAge_ExcludeStockNumAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.radioButtonStockAge_ExcludeStockNumAux.Name = "radioButtonStockAge_ExcludeStockNumAux";
-      this.radioButtonStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(302, 17);
+      this.radioButtonStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(370, 20);
       this.radioButtonStockAge_ExcludeStockNumAux.TabIndex = 4;
       this.radioButtonStockAge_ExcludeStockNumAux.TabStop = true;
       this.radioButtonStockAge_ExcludeStockNumAux.Text = "Output Stock Of Age, Auxiliary Files EXCEPT Stock of Age";
@@ -389,9 +540,10 @@
       // radioButtonStockAge_NoAux
       // 
       this.radioButtonStockAge_NoAux.AutoSize = true;
-      this.radioButtonStockAge_NoAux.Location = new System.Drawing.Point(17, 86);
+      this.radioButtonStockAge_NoAux.Location = new System.Drawing.Point(23, 106);
+      this.radioButtonStockAge_NoAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.radioButtonStockAge_NoAux.Name = "radioButtonStockAge_NoAux";
-      this.radioButtonStockAge_NoAux.Size = new System.Drawing.Size(211, 17);
+      this.radioButtonStockAge_NoAux.Size = new System.Drawing.Size(258, 20);
       this.radioButtonStockAge_NoAux.TabIndex = 3;
       this.radioButtonStockAge_NoAux.TabStop = true;
       this.radioButtonStockAge_NoAux.Text = "Ouptut Stock Of Age, NO Auxiilary Files";
@@ -401,9 +553,10 @@
       // radioButtonNoStockAge_NoAux
       // 
       this.radioButtonNoStockAge_NoAux.AutoSize = true;
-      this.radioButtonNoStockAge_NoAux.Location = new System.Drawing.Point(17, 63);
+      this.radioButtonNoStockAge_NoAux.Location = new System.Drawing.Point(23, 78);
+      this.radioButtonNoStockAge_NoAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.radioButtonNoStockAge_NoAux.Name = "radioButtonNoStockAge_NoAux";
-      this.radioButtonNoStockAge_NoAux.Size = new System.Drawing.Size(194, 17);
+      this.radioButtonNoStockAge_NoAux.Size = new System.Drawing.Size(240, 20);
       this.radioButtonNoStockAge_NoAux.TabIndex = 2;
       this.radioButtonNoStockAge_NoAux.TabStop = true;
       this.radioButtonNoStockAge_NoAux.Text = "NO Stock Of Age and Auxiliary Files";
@@ -413,9 +566,10 @@
       // radioButtonStockAge_AllAux
       // 
       this.radioButtonStockAge_AllAux.AutoSize = true;
-      this.radioButtonStockAge_AllAux.Location = new System.Drawing.Point(17, 40);
+      this.radioButtonStockAge_AllAux.Location = new System.Drawing.Point(23, 49);
+      this.radioButtonStockAge_AllAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.radioButtonStockAge_AllAux.Name = "radioButtonStockAge_AllAux";
-      this.radioButtonStockAge_AllAux.Size = new System.Drawing.Size(234, 17);
+      this.radioButtonStockAge_AllAux.Size = new System.Drawing.Size(285, 20);
       this.radioButtonStockAge_AllAux.TabIndex = 1;
       this.radioButtonStockAge_AllAux.TabStop = true;
       this.radioButtonStockAge_AllAux.Text = "Output Stock Of Age AND ALL Auxiliary files";
@@ -425,9 +579,10 @@
       // radioButtonNoStockAge_ExcludeStockNumAux
       // 
       this.radioButtonNoStockAge_ExcludeStockNumAux.AutoSize = true;
-      this.radioButtonNoStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 17);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(23, 21);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.radioButtonNoStockAge_ExcludeStockNumAux.Name = "radioButtonNoStockAge_ExcludeStockNumAux";
-      this.radioButtonNoStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(359, 17);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(442, 20);
       this.radioButtonNoStockAge_ExcludeStockNumAux.TabIndex = 0;
       this.radioButtonNoStockAge_ExcludeStockNumAux.TabStop = true;
       this.radioButtonNoStockAge_ExcludeStockNumAux.Text = "No Stock of Age, Output Auxiliary files EXCEPT Stock Numbers of Age";
@@ -438,137 +593,32 @@
       // 
       this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
       this.groupOutputViewer.Controls.Add(this.labelOutputViewerProgram);
-      this.groupOutputViewer.Location = new System.Drawing.Point(441, 45);
+      this.groupOutputViewer.Location = new System.Drawing.Point(588, 55);
+      this.groupOutputViewer.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.groupOutputViewer.Name = "groupOutputViewer";
-      this.groupOutputViewer.Size = new System.Drawing.Size(390, 65);
+      this.groupOutputViewer.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupOutputViewer.Size = new System.Drawing.Size(520, 80);
       this.groupOutputViewer.TabIndex = 3;
       this.groupOutputViewer.TabStop = false;
       this.groupOutputViewer.Text = "Output File Viewer";
       // 
-      // dataGridRetroAdjustment
+      // checkBoxEnableVer40Format
       // 
-      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
-      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
-      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
-      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
-      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
-      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(17, 40);
-      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
-      this.dataGridRetroAdjustment.nftReadOnly = false;
-      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
-      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 171);
-      this.dataGridRetroAdjustment.TabIndex = 0;
-      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
-      // 
-      // textBoxScaleFactorRecruits
-      // 
-      this.textBoxScaleFactorRecruits.Enabled = false;
-      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(146, 69);
-      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
-      this.textBoxScaleFactorRecruits.ParamName = null;
-      this.textBoxScaleFactorRecruits.PrevValidValue = "";
-      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorRecruits.TabIndex = 4;
-      // 
-      // textBoxScaleFactorsStockNum
-      // 
-      this.textBoxScaleFactorsStockNum.Enabled = false;
-      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(146, 95);
-      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
-      this.textBoxScaleFactorsStockNum.ParamName = null;
-      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
-      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorsStockNum.TabIndex = 6;
-      // 
-      // textBoxScaleFactorBiomass
-      // 
-      this.textBoxScaleFactorBiomass.Enabled = false;
-      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(146, 43);
-      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
-      this.textBoxScaleFactorBiomass.ParamName = null;
-      this.textBoxScaleFactorBiomass.PrevValidValue = "";
-      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorBiomass.TabIndex = 2;
-      // 
-      // textBoxBoundsNatMortality
-      // 
-      this.textBoxBoundsNatMortality.Enabled = false;
-      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
-      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
-      this.textBoxBoundsNatMortality.ParamName = null;
-      this.textBoxBoundsNatMortality.PrevValidValue = "";
-      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
-      this.textBoxBoundsNatMortality.TabIndex = 4;
-      this.textBoxBoundsNatMortality.Text = "1.0";
-      // 
-      // textBoxBoundsMaxWeight
-      // 
-      this.textBoxBoundsMaxWeight.Enabled = false;
-      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
-      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
-      this.textBoxBoundsMaxWeight.ParamName = null;
-      this.textBoxBoundsMaxWeight.PrevValidValue = "";
-      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
-      this.textBoxBoundsMaxWeight.TabIndex = 2;
-      this.textBoxBoundsMaxWeight.Text = "10.0";
-      // 
-      // textBoxRefFishMortality
-      // 
-      this.textBoxRefFishMortality.Enabled = false;
-      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
-      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
-      this.textBoxRefFishMortality.ParamName = null;
-      this.textBoxRefFishMortality.PrevValidValue = "";
-      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefFishMortality.TabIndex = 8;
-      // 
-      // textBoxRefMeanBiomass
-      // 
-      this.textBoxRefMeanBiomass.Enabled = false;
-      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
-      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
-      this.textBoxRefMeanBiomass.ParamName = null;
-      this.textBoxRefMeanBiomass.PrevValidValue = "";
-      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefMeanBiomass.TabIndex = 6;
-      // 
-      // textBoxRefJan1Biomass
-      // 
-      this.textBoxRefJan1Biomass.Enabled = false;
-      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
-      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
-      this.textBoxRefJan1Biomass.ParamName = null;
-      this.textBoxRefJan1Biomass.PrevValidValue = "";
-      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefJan1Biomass.TabIndex = 4;
-      // 
-      // textBoxRefSpawnBiomass
-      // 
-      this.textBoxRefSpawnBiomass.Enabled = false;
-      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
-      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
-      this.textBoxRefSpawnBiomass.ParamName = null;
-      this.textBoxRefSpawnBiomass.PrevValidValue = "";
-      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefSpawnBiomass.TabIndex = 2;
-      // 
-      // checkBoxVer40Format
-      // 
-      this.checkBoxVer40Format.AutoSize = true;
-      this.checkBoxVer40Format.Location = new System.Drawing.Point(442, 22);
-      this.checkBoxVer40Format.Name = "checkBoxVer40Format";
-      this.checkBoxVer40Format.Size = new System.Drawing.Size(256, 17);
-      this.checkBoxVer40Format.TabIndex = 7;
-      this.checkBoxVer40Format.Text = "Enable AGEPRO VERSION 4.0 input File Format";
-      this.checkBoxVer40Format.UseVisualStyleBackColor = true;
-      this.checkBoxVer40Format.CheckedChanged += new System.EventHandler(this.checkBoxVer40Format_CheckedChanged);
+      this.checkBoxEnableVer40Format.AutoSize = true;
+      this.checkBoxEnableVer40Format.Location = new System.Drawing.Point(589, 27);
+      this.checkBoxEnableVer40Format.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxEnableVer40Format.Name = "checkBoxEnableVer40Format";
+      this.checkBoxEnableVer40Format.Size = new System.Drawing.Size(316, 20);
+      this.checkBoxEnableVer40Format.TabIndex = 7;
+      this.checkBoxEnableVer40Format.Text = "Enable AGEPRO VERSION 4.0 input File Format";
+      this.checkBoxEnableVer40Format.UseVisualStyleBackColor = true;
+      this.checkBoxEnableVer40Format.CheckedChanged += new System.EventHandler(this.checkBoxEnableVer40Format_CheckedChanged);
       // 
       // ControlMiscOptions
       // 
-      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
       this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-      this.Controls.Add(this.checkBoxVer40Format);
+      this.Controls.Add(this.checkBoxEnableVer40Format);
       this.Controls.Add(this.groupOutputViewer);
       this.Controls.Add(this.groupBox_StockSummmaryFlag);
       this.Controls.Add(this.groupRetroAdjustment);
@@ -576,8 +626,9 @@
       this.Controls.Add(this.groupBounds);
       this.Controls.Add(this.groupRefpoints);
       this.Controls.Add(this.groupOuputOptions);
+      this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.Name = "ControlMiscOptions";
-      this.Size = new System.Drawing.Size(900, 520);
+      this.Size = new System.Drawing.Size(1200, 640);
       this.groupOuputOptions.ResumeLayout(false);
       this.groupOuputOptions.PerformLayout();
       ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).EndInit();
@@ -589,11 +640,11 @@
       this.groupScaleFactors.PerformLayout();
       this.groupRetroAdjustment.ResumeLayout(false);
       this.groupRetroAdjustment.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.groupBox_StockSummmaryFlag.ResumeLayout(false);
       this.groupBox_StockSummmaryFlag.PerformLayout();
       this.groupOutputViewer.ResumeLayout(false);
       this.groupOutputViewer.PerformLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.ResumeLayout(false);
       this.PerformLayout();
 
@@ -643,6 +694,6 @@
     private System.Windows.Forms.RadioButton radioButtonStockAge_NoAux;
     private System.Windows.Forms.GroupBox groupOutputViewer;
     private System.Windows.Forms.RadioButton radioButtonStockAge_ExcludeStockNumAux;
-    private System.Windows.Forms.CheckBox checkBoxVer40Format;
+    private System.Windows.Forms.CheckBox checkBoxEnableVer40Format;
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -35,51 +35,51 @@
       this.checkBoxEnableExportR = new System.Windows.Forms.CheckBox();
       this.checkBoxEnableAuxStochasticFiles = new System.Windows.Forms.CheckBox();
       this.groupRefpoints = new System.Windows.Forms.GroupBox();
-      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelFishMortality = new System.Windows.Forms.Label();
-      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.checkBoxEnableRefpoints = new System.Windows.Forms.CheckBox();
       this.labelMeanBiomass = new System.Windows.Forms.Label();
-      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelJan1Biomass = new System.Windows.Forms.Label();
-      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelSpawnBiomass = new System.Windows.Forms.Label();
       this.groupBounds = new System.Windows.Forms.GroupBox();
-      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsNatMortality = new System.Windows.Forms.Label();
-      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsMaxWeight = new System.Windows.Forms.Label();
       this.checkBoxBounds = new System.Windows.Forms.CheckBox();
       this.groupScaleFactors = new System.Windows.Forms.GroupBox();
-      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorRecruits = new System.Windows.Forms.Label();
-      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorStockNum = new System.Windows.Forms.Label();
-      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorBiomass = new System.Windows.Forms.Label();
       this.checkBoxEnableScaleFactors = new System.Windows.Forms.CheckBox();
       this.groupRetroAdjustment = new System.Windows.Forms.GroupBox();
       this.checkBoxEnableRetroAdjustment = new System.Windows.Forms.CheckBox();
-      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
       this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
-      this.radioButtonOutfileAppendStockExcludeStockAux = new System.Windows.Forms.RadioButton();
-      this.radioButtonOnlyOutfileAppendStock = new System.Windows.Forms.RadioButton();
-      this.radioButtonOnlyOutfileNoStock = new System.Windows.Forms.RadioButton();
-      this.radioButtonOutfileAppendStockAllAux = new System.Windows.Forms.RadioButton();
-      this.radioButtonOutfileNoStockExcludeStockAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonStockAge_ExcludeStockNumAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonStockAge_NoAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonNoStockAge_NoAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonStockAge_AllAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonNoStockAge_ExcludeStockNumAux = new System.Windows.Forms.RadioButton();
       this.groupOutputViewer = new System.Windows.Forms.GroupBox();
-      this.checkBoxEnableSummaryReport = new System.Windows.Forms.CheckBox();
+      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
+      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.checkBoxVer40Format = new System.Windows.Forms.CheckBox();
       this.groupOuputOptions.SuspendLayout();
       ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).BeginInit();
       this.groupRefpoints.SuspendLayout();
       this.groupBounds.SuspendLayout();
       this.groupScaleFactors.SuspendLayout();
       this.groupRetroAdjustment.SuspendLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.groupBox_StockSummmaryFlag.SuspendLayout();
       this.groupOutputViewer.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.SuspendLayout();
       // 
       // groupOuputOptions
@@ -157,22 +157,12 @@
       this.groupRefpoints.Controls.Add(this.labelJan1Biomass);
       this.groupRefpoints.Controls.Add(this.textBoxRefSpawnBiomass);
       this.groupRefpoints.Controls.Add(this.labelSpawnBiomass);
-      this.groupRefpoints.Location = new System.Drawing.Point(441, 191);
+      this.groupRefpoints.Location = new System.Drawing.Point(441, 219);
       this.groupRefpoints.Name = "groupRefpoints";
       this.groupRefpoints.Size = new System.Drawing.Size(390, 152);
       this.groupRefpoints.TabIndex = 5;
       this.groupRefpoints.TabStop = false;
       this.groupRefpoints.Text = "Reference Points";
-      // 
-      // textBoxRefFishMortality
-      // 
-      this.textBoxRefFishMortality.Enabled = false;
-      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
-      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
-      this.textBoxRefFishMortality.ParamName = null;
-      this.textBoxRefFishMortality.PrevValidValue = "";
-      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefFishMortality.TabIndex = 8;
       // 
       // labelFishMortality
       // 
@@ -183,16 +173,6 @@
       this.labelFishMortality.Size = new System.Drawing.Size(82, 13);
       this.labelFishMortality.TabIndex = 7;
       this.labelFishMortality.Text = "Fishing Mortality";
-      // 
-      // textBoxRefMeanBiomass
-      // 
-      this.textBoxRefMeanBiomass.Enabled = false;
-      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
-      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
-      this.textBoxRefMeanBiomass.ParamName = null;
-      this.textBoxRefMeanBiomass.PrevValidValue = "";
-      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefMeanBiomass.TabIndex = 6;
       // 
       // checkBoxEnableRefpoints
       // 
@@ -215,16 +195,6 @@
       this.labelMeanBiomass.TabIndex = 5;
       this.labelMeanBiomass.Text = "Mean Biomass (MT)";
       // 
-      // textBoxRefJan1Biomass
-      // 
-      this.textBoxRefJan1Biomass.Enabled = false;
-      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
-      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
-      this.textBoxRefJan1Biomass.ParamName = null;
-      this.textBoxRefJan1Biomass.PrevValidValue = "";
-      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefJan1Biomass.TabIndex = 4;
-      // 
       // labelJan1Biomass
       // 
       this.labelJan1Biomass.AutoSize = true;
@@ -234,16 +204,6 @@
       this.labelJan1Biomass.Size = new System.Drawing.Size(131, 13);
       this.labelJan1Biomass.TabIndex = 3;
       this.labelJan1Biomass.Text = "Jan-1 Stock Biomass (MT)";
-      // 
-      // textBoxRefSpawnBiomass
-      // 
-      this.textBoxRefSpawnBiomass.Enabled = false;
-      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
-      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
-      this.textBoxRefSpawnBiomass.ParamName = null;
-      this.textBoxRefSpawnBiomass.PrevValidValue = "";
-      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefSpawnBiomass.TabIndex = 2;
       // 
       // labelSpawnBiomass
       // 
@@ -262,23 +222,12 @@
       this.groupBounds.Controls.Add(this.textBoxBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.labelBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.checkBoxBounds);
-      this.groupBounds.Location = new System.Drawing.Point(441, 86);
+      this.groupBounds.Location = new System.Drawing.Point(441, 114);
       this.groupBounds.Name = "groupBounds";
       this.groupBounds.Size = new System.Drawing.Size(390, 99);
       this.groupBounds.TabIndex = 4;
       this.groupBounds.TabStop = false;
       this.groupBounds.Text = "Bounds";
-      // 
-      // textBoxBoundsNatMortality
-      // 
-      this.textBoxBoundsNatMortality.Enabled = false;
-      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
-      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
-      this.textBoxBoundsNatMortality.ParamName = null;
-      this.textBoxBoundsNatMortality.PrevValidValue = "";
-      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
-      this.textBoxBoundsNatMortality.TabIndex = 4;
-      this.textBoxBoundsNatMortality.Text = "1.0";
       // 
       // labelBoundsNatMortality
       // 
@@ -289,17 +238,6 @@
       this.labelBoundsNatMortality.Size = new System.Drawing.Size(130, 13);
       this.labelBoundsNatMortality.TabIndex = 3;
       this.labelBoundsNatMortality.Text = "Maximum Natural Mortality";
-      // 
-      // textBoxBoundsMaxWeight
-      // 
-      this.textBoxBoundsMaxWeight.Enabled = false;
-      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
-      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
-      this.textBoxBoundsMaxWeight.ParamName = null;
-      this.textBoxBoundsMaxWeight.PrevValidValue = "";
-      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
-      this.textBoxBoundsMaxWeight.TabIndex = 2;
-      this.textBoxBoundsMaxWeight.Text = "10.0";
       // 
       // labelBoundsMaxWeight
       // 
@@ -331,68 +269,38 @@
       this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.labelScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.checkBoxEnableScaleFactors);
-      this.groupScaleFactors.Location = new System.Drawing.Point(441, 349);
+      this.groupScaleFactors.Location = new System.Drawing.Point(441, 377);
       this.groupScaleFactors.Name = "groupScaleFactors";
-      this.groupScaleFactors.Size = new System.Drawing.Size(390, 134);
+      this.groupScaleFactors.Size = new System.Drawing.Size(390, 128);
       this.groupScaleFactors.TabIndex = 6;
       this.groupScaleFactors.TabStop = false;
       this.groupScaleFactors.Text = "Scaling Factors for Output Report";
-      // 
-      // textBoxScaleFactorRecruits
-      // 
-      this.textBoxScaleFactorRecruits.Enabled = false;
-      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(144, 74);
-      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
-      this.textBoxScaleFactorRecruits.ParamName = null;
-      this.textBoxScaleFactorRecruits.PrevValidValue = "";
-      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorRecruits.TabIndex = 4;
       // 
       // labelScaleFactorRecruits
       // 
       this.labelScaleFactorRecruits.AutoSize = true;
       this.labelScaleFactorRecruits.Enabled = false;
-      this.labelScaleFactorRecruits.Location = new System.Drawing.Point(20, 77);
+      this.labelScaleFactorRecruits.Location = new System.Drawing.Point(22, 72);
       this.labelScaleFactorRecruits.Name = "labelScaleFactorRecruits";
       this.labelScaleFactorRecruits.Size = new System.Drawing.Size(46, 13);
       this.labelScaleFactorRecruits.TabIndex = 3;
       this.labelScaleFactorRecruits.Text = "Recruits";
       // 
-      // textBoxScaleFactorsStockNum
-      // 
-      this.textBoxScaleFactorsStockNum.Enabled = false;
-      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(144, 100);
-      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
-      this.textBoxScaleFactorsStockNum.ParamName = null;
-      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
-      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorsStockNum.TabIndex = 6;
-      // 
       // labelScaleFactorStockNum
       // 
       this.labelScaleFactorStockNum.AutoSize = true;
       this.labelScaleFactorStockNum.Enabled = false;
-      this.labelScaleFactorStockNum.Location = new System.Drawing.Point(19, 103);
+      this.labelScaleFactorStockNum.Location = new System.Drawing.Point(21, 98);
       this.labelScaleFactorStockNum.Name = "labelScaleFactorStockNum";
       this.labelScaleFactorStockNum.Size = new System.Drawing.Size(80, 13);
       this.labelScaleFactorStockNum.TabIndex = 5;
       this.labelScaleFactorStockNum.Text = "Stock Numbers";
       // 
-      // textBoxScaleFactorBiomass
-      // 
-      this.textBoxScaleFactorBiomass.Enabled = false;
-      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(144, 48);
-      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
-      this.textBoxScaleFactorBiomass.ParamName = null;
-      this.textBoxScaleFactorBiomass.PrevValidValue = "";
-      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorBiomass.TabIndex = 2;
-      // 
       // labelScaleFactorBiomass
       // 
       this.labelScaleFactorBiomass.AutoSize = true;
       this.labelScaleFactorBiomass.Enabled = false;
-      this.labelScaleFactorBiomass.Location = new System.Drawing.Point(20, 51);
+      this.labelScaleFactorBiomass.Location = new System.Drawing.Point(22, 46);
       this.labelScaleFactorBiomass.Name = "labelScaleFactorBiomass";
       this.labelScaleFactorBiomass.Size = new System.Drawing.Size(46, 13);
       this.labelScaleFactorBiomass.TabIndex = 1;
@@ -431,22 +339,6 @@
       this.checkBoxEnableRetroAdjustment.UseVisualStyleBackColor = true;
       this.checkBoxEnableRetroAdjustment.CheckedChanged += new System.EventHandler(this.CheckBoxRetroAdjustment_CheckedChanged);
       // 
-      // dataGridRetroAdjustment
-      // 
-      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
-      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
-      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
-      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
-      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
-      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(17, 40);
-      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
-      this.dataGridRetroAdjustment.nftReadOnly = false;
-      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
-      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 171);
-      this.dataGridRetroAdjustment.TabIndex = 0;
-      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
-      // 
       // comboBoxOutputViewerProgram
       // 
       this.comboBoxOutputViewerProgram.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -470,11 +362,11 @@
       // 
       // groupBox_StockSummmaryFlag
       // 
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOutfileAppendStockExcludeStockAux);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOnlyOutfileAppendStock);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOnlyOutfileNoStock);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOutfileAppendStockAllAux);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOutfileNoStockExcludeStockAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockAge_ExcludeStockNumAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockAge_NoAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockAge_NoAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockAge_AllAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockAge_ExcludeStockNumAux);
       this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
       this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
       this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(406, 133);
@@ -482,89 +374,207 @@
       this.groupBox_StockSummmaryFlag.TabStop = false;
       this.groupBox_StockSummmaryFlag.Text = "Stock Distribution Summary and Auxiliary Data Files";
       // 
-      // radioButtonOutfileAppendStockExcludeStockAux
+      // radioButtonStockAge_ExcludeStockNumAux
       // 
-      this.radioButtonOutfileAppendStockExcludeStockAux.AutoSize = true;
-      this.radioButtonOutfileAppendStockExcludeStockAux.Location = new System.Drawing.Point(17, 109);
-      this.radioButtonOutfileAppendStockExcludeStockAux.Name = "radioButtonOutfileAppendStockExcludeStockAux";
-      this.radioButtonOutfileAppendStockExcludeStockAux.Size = new System.Drawing.Size(367, 17);
-      this.radioButtonOutfileAppendStockExcludeStockAux.TabIndex = 4;
-      this.radioButtonOutfileAppendStockExcludeStockAux.TabStop = true;
-      this.radioButtonOutfileAppendStockExcludeStockAux.Text = "Output File with Stock Distributions, Auxiliary Files EXCEPT Stock of Age";
-      this.radioButtonOutfileAppendStockExcludeStockAux.UseVisualStyleBackColor = true;
-      this.radioButtonOutfileAppendStockExcludeStockAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
+      this.radioButtonStockAge_ExcludeStockNumAux.AutoSize = true;
+      this.radioButtonStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 109);
+      this.radioButtonStockAge_ExcludeStockNumAux.Name = "radioButtonStockAge_ExcludeStockNumAux";
+      this.radioButtonStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(302, 17);
+      this.radioButtonStockAge_ExcludeStockNumAux.TabIndex = 4;
+      this.radioButtonStockAge_ExcludeStockNumAux.TabStop = true;
+      this.radioButtonStockAge_ExcludeStockNumAux.Text = "Output Stock Of Age, Auxiliary Files EXCEPT Stock of Age";
+      this.radioButtonStockAge_ExcludeStockNumAux.UseVisualStyleBackColor = true;
+      this.radioButtonStockAge_ExcludeStockNumAux.CheckedChanged += new System.EventHandler(this.radioButtonStockAge_ExcludeStockNumAux_CheckedChanged);
       // 
-      // radioButtonOnlyOutfileAppendStock
+      // radioButtonStockAge_NoAux
       // 
-      this.radioButtonOnlyOutfileAppendStock.AutoSize = true;
-      this.radioButtonOnlyOutfileAppendStock.Location = new System.Drawing.Point(17, 86);
-      this.radioButtonOnlyOutfileAppendStock.Name = "radioButtonOnlyOutfileAppendStock";
-      this.radioButtonOnlyOutfileAppendStock.Size = new System.Drawing.Size(221, 17);
-      this.radioButtonOnlyOutfileAppendStock.TabIndex = 3;
-      this.radioButtonOnlyOutfileAppendStock.TabStop = true;
-      this.radioButtonOnlyOutfileAppendStock.Text = "ONLY Output File with Stock Distributions";
-      this.radioButtonOnlyOutfileAppendStock.UseVisualStyleBackColor = true;
-      this.radioButtonOnlyOutfileAppendStock.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
+      this.radioButtonStockAge_NoAux.AutoSize = true;
+      this.radioButtonStockAge_NoAux.Location = new System.Drawing.Point(17, 86);
+      this.radioButtonStockAge_NoAux.Name = "radioButtonStockAge_NoAux";
+      this.radioButtonStockAge_NoAux.Size = new System.Drawing.Size(211, 17);
+      this.radioButtonStockAge_NoAux.TabIndex = 3;
+      this.radioButtonStockAge_NoAux.TabStop = true;
+      this.radioButtonStockAge_NoAux.Text = "Ouptut Stock Of Age, NO Auxiilary Files";
+      this.radioButtonStockAge_NoAux.UseVisualStyleBackColor = true;
+      this.radioButtonStockAge_NoAux.CheckedChanged += new System.EventHandler(this.radioButtonStockAge_NoAux_CheckedChanged);
       // 
-      // radioButtonOnlyOutfileNoStock
+      // radioButtonNoStockAge_NoAux
       // 
-      this.radioButtonOnlyOutfileNoStock.AutoSize = true;
-      this.radioButtonOnlyOutfileNoStock.Location = new System.Drawing.Point(17, 63);
-      this.radioButtonOnlyOutfileNoStock.Name = "radioButtonOnlyOutfileNoStock";
-      this.radioButtonOnlyOutfileNoStock.Size = new System.Drawing.Size(224, 17);
-      this.radioButtonOnlyOutfileNoStock.TabIndex = 2;
-      this.radioButtonOnlyOutfileNoStock.TabStop = true;
-      this.radioButtonOnlyOutfileNoStock.Text = "ONLY Output File (NO Stock Distributions)";
-      this.radioButtonOnlyOutfileNoStock.UseVisualStyleBackColor = true;
-      this.radioButtonOnlyOutfileNoStock.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryNoAux1_CheckedChanged);
+      this.radioButtonNoStockAge_NoAux.AutoSize = true;
+      this.radioButtonNoStockAge_NoAux.Location = new System.Drawing.Point(17, 63);
+      this.radioButtonNoStockAge_NoAux.Name = "radioButtonNoStockAge_NoAux";
+      this.radioButtonNoStockAge_NoAux.Size = new System.Drawing.Size(194, 17);
+      this.radioButtonNoStockAge_NoAux.TabIndex = 2;
+      this.radioButtonNoStockAge_NoAux.TabStop = true;
+      this.radioButtonNoStockAge_NoAux.Text = "NO Stock Of Age and Auxiliary Files";
+      this.radioButtonNoStockAge_NoAux.UseVisualStyleBackColor = true;
+      this.radioButtonNoStockAge_NoAux.CheckedChanged += new System.EventHandler(this.radioButtonNoStockAge_NoAux_CheckedChanged);
       // 
-      // radioButtonOutfileAppendStockAllAux
+      // radioButtonStockAge_AllAux
       // 
-      this.radioButtonOutfileAppendStockAllAux.AutoSize = true;
-      this.radioButtonOutfileAppendStockAllAux.Location = new System.Drawing.Point(17, 40);
-      this.radioButtonOutfileAppendStockAllAux.Name = "radioButtonOutfileAppendStockAllAux";
-      this.radioButtonOutfileAppendStockAllAux.Size = new System.Drawing.Size(273, 17);
-      this.radioButtonOutfileAppendStockAllAux.TabIndex = 1;
-      this.radioButtonOutfileAppendStockAllAux.TabStop = true;
-      this.radioButtonOutfileAppendStockAllAux.Text = "Output file with Stock Distributions, ALL Auxiliary files";
-      this.radioButtonOutfileAppendStockAllAux.UseVisualStyleBackColor = true;
-      this.radioButtonOutfileAppendStockAllAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryOnly_CheckedChanged);
+      this.radioButtonStockAge_AllAux.AutoSize = true;
+      this.radioButtonStockAge_AllAux.Location = new System.Drawing.Point(17, 40);
+      this.radioButtonStockAge_AllAux.Name = "radioButtonStockAge_AllAux";
+      this.radioButtonStockAge_AllAux.Size = new System.Drawing.Size(234, 17);
+      this.radioButtonStockAge_AllAux.TabIndex = 1;
+      this.radioButtonStockAge_AllAux.TabStop = true;
+      this.radioButtonStockAge_AllAux.Text = "Output Stock Of Age AND ALL Auxiliary files";
+      this.radioButtonStockAge_AllAux.UseVisualStyleBackColor = true;
+      this.radioButtonStockAge_AllAux.CheckedChanged += new System.EventHandler(this.radioButtonStockAge_AllAux_CheckedChanged);
       // 
-      // radioButtonOutfileNoStockExcludeStockAux
+      // radioButtonNoStockAge_ExcludeStockNumAux
       // 
-      this.radioButtonOutfileNoStockExcludeStockAux.AutoSize = true;
-      this.radioButtonOutfileNoStockExcludeStockAux.Location = new System.Drawing.Point(17, 17);
-      this.radioButtonOutfileNoStockExcludeStockAux.Name = "radioButtonOutfileNoStockExcludeStockAux";
-      this.radioButtonOutfileNoStockExcludeStockAux.Size = new System.Drawing.Size(376, 17);
-      this.radioButtonOutfileNoStockExcludeStockAux.TabIndex = 0;
-      this.radioButtonOutfileNoStockExcludeStockAux.TabStop = true;
-      this.radioButtonOutfileNoStockExcludeStockAux.Text = "Output file without Stock Distributions, Auxiliary files EXCEPT Stock of Age";
-      this.radioButtonOutfileNoStockExcludeStockAux.UseVisualStyleBackColor = true;
-      this.radioButtonOutfileNoStockExcludeStockAux.CheckedChanged += new System.EventHandler(this.RadioButtonNone_CheckedChanged);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.AutoSize = true;
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 17);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Name = "radioButtonNoStockAge_ExcludeStockNumAux";
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(359, 17);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.TabIndex = 0;
+      this.radioButtonNoStockAge_ExcludeStockNumAux.TabStop = true;
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Text = "No Stock of Age, Output Auxiliary files EXCEPT Stock Numbers of Age";
+      this.radioButtonNoStockAge_ExcludeStockNumAux.UseVisualStyleBackColor = true;
+      this.radioButtonNoStockAge_ExcludeStockNumAux.CheckedChanged += new System.EventHandler(this.radioButtonNoStockAge_ExcludeStockNumAux_CheckedChanged);
       // 
       // groupOutputViewer
       // 
       this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
       this.groupOutputViewer.Controls.Add(this.labelOutputViewerProgram);
-      this.groupOutputViewer.Location = new System.Drawing.Point(441, 15);
+      this.groupOutputViewer.Location = new System.Drawing.Point(441, 45);
       this.groupOutputViewer.Name = "groupOutputViewer";
       this.groupOutputViewer.Size = new System.Drawing.Size(390, 65);
       this.groupOutputViewer.TabIndex = 3;
       this.groupOutputViewer.TabStop = false;
       this.groupOutputViewer.Text = "Output File Viewer";
-
+      // 
+      // dataGridRetroAdjustment
+      // 
+      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
+      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
+      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
+      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
+      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
+      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(17, 40);
+      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
+      this.dataGridRetroAdjustment.nftReadOnly = false;
+      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
+      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 171);
+      this.dataGridRetroAdjustment.TabIndex = 0;
+      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
+      // 
+      // textBoxScaleFactorRecruits
+      // 
+      this.textBoxScaleFactorRecruits.Enabled = false;
+      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(146, 69);
+      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
+      this.textBoxScaleFactorRecruits.ParamName = null;
+      this.textBoxScaleFactorRecruits.PrevValidValue = "";
+      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorRecruits.TabIndex = 4;
+      // 
+      // textBoxScaleFactorsStockNum
+      // 
+      this.textBoxScaleFactorsStockNum.Enabled = false;
+      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(146, 95);
+      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
+      this.textBoxScaleFactorsStockNum.ParamName = null;
+      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
+      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorsStockNum.TabIndex = 6;
+      // 
+      // textBoxScaleFactorBiomass
+      // 
+      this.textBoxScaleFactorBiomass.Enabled = false;
+      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(146, 43);
+      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
+      this.textBoxScaleFactorBiomass.ParamName = null;
+      this.textBoxScaleFactorBiomass.PrevValidValue = "";
+      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorBiomass.TabIndex = 2;
+      // 
+      // textBoxBoundsNatMortality
+      // 
+      this.textBoxBoundsNatMortality.Enabled = false;
+      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
+      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
+      this.textBoxBoundsNatMortality.ParamName = null;
+      this.textBoxBoundsNatMortality.PrevValidValue = "";
+      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsNatMortality.TabIndex = 4;
+      this.textBoxBoundsNatMortality.Text = "1.0";
+      // 
+      // textBoxBoundsMaxWeight
+      // 
+      this.textBoxBoundsMaxWeight.Enabled = false;
+      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
+      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
+      this.textBoxBoundsMaxWeight.ParamName = null;
+      this.textBoxBoundsMaxWeight.PrevValidValue = "";
+      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsMaxWeight.TabIndex = 2;
+      this.textBoxBoundsMaxWeight.Text = "10.0";
+      // 
+      // textBoxRefFishMortality
+      // 
+      this.textBoxRefFishMortality.Enabled = false;
+      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
+      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
+      this.textBoxRefFishMortality.ParamName = null;
+      this.textBoxRefFishMortality.PrevValidValue = "";
+      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefFishMortality.TabIndex = 8;
+      // 
+      // textBoxRefMeanBiomass
+      // 
+      this.textBoxRefMeanBiomass.Enabled = false;
+      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
+      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
+      this.textBoxRefMeanBiomass.ParamName = null;
+      this.textBoxRefMeanBiomass.PrevValidValue = "";
+      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefMeanBiomass.TabIndex = 6;
+      // 
+      // textBoxRefJan1Biomass
+      // 
+      this.textBoxRefJan1Biomass.Enabled = false;
+      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
+      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
+      this.textBoxRefJan1Biomass.ParamName = null;
+      this.textBoxRefJan1Biomass.PrevValidValue = "";
+      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefJan1Biomass.TabIndex = 4;
+      // 
+      // textBoxRefSpawnBiomass
+      // 
+      this.textBoxRefSpawnBiomass.Enabled = false;
+      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
+      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
+      this.textBoxRefSpawnBiomass.ParamName = null;
+      this.textBoxRefSpawnBiomass.PrevValidValue = "";
+      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefSpawnBiomass.TabIndex = 2;
+      // 
+      // checkBoxVer40Format
+      // 
+      this.checkBoxVer40Format.AutoSize = true;
+      this.checkBoxVer40Format.Location = new System.Drawing.Point(442, 22);
+      this.checkBoxVer40Format.Name = "checkBoxVer40Format";
+      this.checkBoxVer40Format.Size = new System.Drawing.Size(256, 17);
+      this.checkBoxVer40Format.TabIndex = 7;
+      this.checkBoxVer40Format.Text = "Enable AGEPRO VERSION 4.0 input File Format";
+      this.checkBoxVer40Format.UseVisualStyleBackColor = true;
+      this.checkBoxVer40Format.CheckedChanged += new System.EventHandler(this.checkBoxVer40Format_CheckedChanged);
       // 
       // ControlMiscOptions
       // 
       this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
       this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.Controls.Add(this.checkBoxVer40Format);
       this.Controls.Add(this.groupOutputViewer);
       this.Controls.Add(this.groupBox_StockSummmaryFlag);
       this.Controls.Add(this.groupRetroAdjustment);
       this.Controls.Add(this.groupScaleFactors);
       this.Controls.Add(this.groupBounds);
       this.Controls.Add(this.groupRefpoints);
-      this.Controls.Add(this.checkBoxEnableSummaryReport);
       this.Controls.Add(this.groupOuputOptions);
       this.Name = "ControlMiscOptions";
       this.Size = new System.Drawing.Size(900, 520);
@@ -579,11 +589,11 @@
       this.groupScaleFactors.PerformLayout();
       this.groupRetroAdjustment.ResumeLayout(false);
       this.groupRetroAdjustment.PerformLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.groupBox_StockSummmaryFlag.ResumeLayout(false);
       this.groupBox_StockSummmaryFlag.PerformLayout();
       this.groupOutputViewer.ResumeLayout(false);
       this.groupOutputViewer.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.ResumeLayout(false);
       this.PerformLayout();
 
@@ -627,12 +637,12 @@
         private System.Windows.Forms.ComboBox comboBoxOutputViewerProgram;
         private System.Windows.Forms.Label labelOutputViewerProgram;
     private System.Windows.Forms.GroupBox groupBox_StockSummmaryFlag;
-    private System.Windows.Forms.RadioButton radioButtonOutfileNoStockExcludeStockAux;
-    private System.Windows.Forms.RadioButton radioButtonOnlyOutfileNoStock;
-    private System.Windows.Forms.RadioButton radioButtonOutfileAppendStockAllAux;
-    private System.Windows.Forms.RadioButton radioButtonOnlyOutfileAppendStock;
+    private System.Windows.Forms.RadioButton radioButtonNoStockAge_ExcludeStockNumAux;
+    private System.Windows.Forms.RadioButton radioButtonNoStockAge_NoAux;
+    private System.Windows.Forms.RadioButton radioButtonStockAge_AllAux;
+    private System.Windows.Forms.RadioButton radioButtonStockAge_NoAux;
     private System.Windows.Forms.GroupBox groupOutputViewer;
-    private System.Windows.Forms.RadioButton radioButtonOutfileAppendStockExcludeStockAux;
-    private System.Windows.Forms.CheckBox checkBoxEnableSummaryReport;
+    private System.Windows.Forms.RadioButton radioButtonStockAge_ExcludeStockNumAux;
+    private System.Windows.Forms.CheckBox checkBoxVer40Format;
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -55,11 +55,12 @@
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
       this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
-      this.radioButtonStockDistExceptAuxStockVector = new System.Windows.Forms.RadioButton();
-      this.radioButtonSummaryStockDistNoAux = new System.Windows.Forms.RadioButton();
-      this.radioButtonStockDistAllAux = new System.Windows.Forms.RadioButton();
-      this.radioButtonNoStockDistAllAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonOnlyOutfileAppendStock = new System.Windows.Forms.RadioButton();
+      this.radioButtonOnlyOutfileNoStock = new System.Windows.Forms.RadioButton();
+      this.radioButtonOutfileAppendStockAllAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonOutfileNoStockExcludeStockAux = new System.Windows.Forms.RadioButton();
       this.groupOutputViewer = new System.Windows.Forms.GroupBox();
+      this.radioButtonOutfileAppendStockExcludeStockAux = new System.Windows.Forms.RadioButton();
       this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
       this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
       this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
@@ -88,9 +89,9 @@
       this.groupOuputOptions.Controls.Add(this.checkBoxEnablePercentileReport);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableExportR);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableAuxStochasticFiles);
-      this.groupOuputOptions.Location = new System.Drawing.Point(29, 144);
+      this.groupOuputOptions.Location = new System.Drawing.Point(29, 154);
       this.groupOuputOptions.Name = "groupOuputOptions";
-      this.groupOuputOptions.Size = new System.Drawing.Size(383, 123);
+      this.groupOuputOptions.Size = new System.Drawing.Size(406, 123);
       this.groupOuputOptions.TabIndex = 1;
       this.groupOuputOptions.TabStop = false;
       this.groupOuputOptions.Text = "Output Options";
@@ -99,7 +100,7 @@
       // 
       this.spinBoxReportPercentile.DecimalPlaces = 1;
       this.spinBoxReportPercentile.Enabled = false;
-      this.spinBoxReportPercentile.Location = new System.Drawing.Point(159, 87);
+      this.spinBoxReportPercentile.Location = new System.Drawing.Point(159, 88);
       this.spinBoxReportPercentile.Name = "spinBoxReportPercentile";
       this.spinBoxReportPercentile.Size = new System.Drawing.Size(107, 20);
       this.spinBoxReportPercentile.TabIndex = 5;
@@ -108,7 +109,7 @@
       // 
       this.labelReportPercentile.AutoSize = true;
       this.labelReportPercentile.Enabled = false;
-      this.labelReportPercentile.Location = new System.Drawing.Point(64, 89);
+      this.labelReportPercentile.Location = new System.Drawing.Point(64, 90);
       this.labelReportPercentile.Name = "labelReportPercentile";
       this.labelReportPercentile.Size = new System.Drawing.Size(89, 13);
       this.labelReportPercentile.TabIndex = 4;
@@ -117,7 +118,7 @@
       // checkBoxEnablePercentileReport
       // 
       this.checkBoxEnablePercentileReport.AutoSize = true;
-      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(17, 65);
+      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(17, 66);
       this.checkBoxEnablePercentileReport.Name = "checkBoxEnablePercentileReport";
       this.checkBoxEnablePercentileReport.Size = new System.Drawing.Size(151, 17);
       this.checkBoxEnablePercentileReport.TabIndex = 3;
@@ -128,7 +129,7 @@
       // checkBoxEnableExportR
       // 
       this.checkBoxEnableExportR.AutoSize = true;
-      this.checkBoxEnableExportR.Location = new System.Drawing.Point(17, 42);
+      this.checkBoxEnableExportR.Location = new System.Drawing.Point(17, 43);
       this.checkBoxEnableExportR.Name = "checkBoxEnableExportR";
       this.checkBoxEnableExportR.Size = new System.Drawing.Size(117, 17);
       this.checkBoxEnableExportR.TabIndex = 2;
@@ -138,7 +139,7 @@
       // checkBoxEnableAuxStochasticFiles
       // 
       this.checkBoxEnableAuxStochasticFiles.AutoSize = true;
-      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(17, 19);
+      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(17, 20);
       this.checkBoxEnableAuxStochasticFiles.Name = "checkBoxEnableAuxStochasticFiles";
       this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(214, 17);
       this.checkBoxEnableAuxStochasticFiles.TabIndex = 4;
@@ -148,7 +149,7 @@
       // checkBoxEnableSummaryReport
       // 
       this.checkBoxEnableSummaryReport.AutoSize = true;
-      this.checkBoxEnableSummaryReport.Location = new System.Drawing.Point(418, 489);
+      this.checkBoxEnableSummaryReport.Location = new System.Drawing.Point(441, 489);
       this.checkBoxEnableSummaryReport.Name = "checkBoxEnableSummaryReport";
       this.checkBoxEnableSummaryReport.Size = new System.Drawing.Size(262, 17);
       this.checkBoxEnableSummaryReport.TabIndex = 7;
@@ -167,7 +168,7 @@
       this.groupRefpoints.Controls.Add(this.labelJan1Biomass);
       this.groupRefpoints.Controls.Add(this.textBoxRefSpawnBiomass);
       this.groupRefpoints.Controls.Add(this.labelSpawnBiomass);
-      this.groupRefpoints.Location = new System.Drawing.Point(418, 191);
+      this.groupRefpoints.Location = new System.Drawing.Point(441, 191);
       this.groupRefpoints.Name = "groupRefpoints";
       this.groupRefpoints.Size = new System.Drawing.Size(390, 152);
       this.groupRefpoints.TabIndex = 5;
@@ -232,7 +233,7 @@
       this.groupBounds.Controls.Add(this.textBoxBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.labelBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.checkBoxBounds);
-      this.groupBounds.Location = new System.Drawing.Point(418, 86);
+      this.groupBounds.Location = new System.Drawing.Point(441, 86);
       this.groupBounds.Name = "groupBounds";
       this.groupBounds.Size = new System.Drawing.Size(390, 99);
       this.groupBounds.TabIndex = 4;
@@ -279,7 +280,7 @@
       this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.labelScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.checkBoxEnableScaleFactors);
-      this.groupScaleFactors.Location = new System.Drawing.Point(418, 349);
+      this.groupScaleFactors.Location = new System.Drawing.Point(441, 349);
       this.groupScaleFactors.Name = "groupScaleFactors";
       this.groupScaleFactors.Size = new System.Drawing.Size(390, 134);
       this.groupScaleFactors.TabIndex = 6;
@@ -331,9 +332,9 @@
       // 
       this.groupRetroAdjustment.Controls.Add(this.checkBoxEnableRetroAdjustment);
       this.groupRetroAdjustment.Controls.Add(this.dataGridRetroAdjustment);
-      this.groupRetroAdjustment.Location = new System.Drawing.Point(29, 273);
+      this.groupRetroAdjustment.Location = new System.Drawing.Point(29, 283);
       this.groupRetroAdjustment.Name = "groupRetroAdjustment";
-      this.groupRetroAdjustment.Size = new System.Drawing.Size(383, 223);
+      this.groupRetroAdjustment.Size = new System.Drawing.Size(406, 223);
       this.groupRetroAdjustment.TabIndex = 2;
       this.groupRetroAdjustment.TabStop = false;
       this.groupRetroAdjustment.Text = "Retrospective Adjustment Factors";
@@ -372,75 +373,88 @@
       // 
       // groupBox_StockSummmaryFlag
       // 
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockDistExceptAuxStockVector);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonSummaryStockDistNoAux);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockDistAllAux);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockDistAllAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOutfileAppendStockExcludeStockAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOnlyOutfileAppendStock);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOnlyOutfileNoStock);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOutfileAppendStockAllAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonOutfileNoStockExcludeStockAux);
       this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
       this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
-      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(383, 123);
+      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(406, 133);
       this.groupBox_StockSummmaryFlag.TabIndex = 0;
       this.groupBox_StockSummmaryFlag.TabStop = false;
       this.groupBox_StockSummmaryFlag.Text = "Stock Distribution Summary and Auxiliary Data Files";
       // 
-      // radioButtonStockDistExceptAuxStockVector
+      // radioButtonOnlyOutfileAppendStock
       // 
-      this.radioButtonStockDistExceptAuxStockVector.AutoSize = true;
-      this.radioButtonStockDistExceptAuxStockVector.Location = new System.Drawing.Point(17, 86);
-      this.radioButtonStockDistExceptAuxStockVector.Name = "radioButtonStockDistExceptAuxStockVector";
-      this.radioButtonStockDistExceptAuxStockVector.Size = new System.Drawing.Size(330, 17);
-      this.radioButtonStockDistExceptAuxStockVector.TabIndex = 3;
-      this.radioButtonStockDistExceptAuxStockVector.TabStop = true;
-      this.radioButtonStockDistExceptAuxStockVector.Text = "Stock Distribution and Auxiliary Files EXCEPT Auxiliary Stock File";
-      this.radioButtonStockDistExceptAuxStockVector.UseVisualStyleBackColor = true;
-      this.radioButtonStockDistExceptAuxStockVector.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
+      this.radioButtonOnlyOutfileAppendStock.AutoSize = true;
+      this.radioButtonOnlyOutfileAppendStock.Location = new System.Drawing.Point(17, 86);
+      this.radioButtonOnlyOutfileAppendStock.Name = "radioButtonOnlyOutfileAppendStock";
+      this.radioButtonOnlyOutfileAppendStock.Size = new System.Drawing.Size(221, 17);
+      this.radioButtonOnlyOutfileAppendStock.TabIndex = 3;
+      this.radioButtonOnlyOutfileAppendStock.TabStop = true;
+      this.radioButtonOnlyOutfileAppendStock.Text = "ONLY Output File with Stock Distributions";
+      this.radioButtonOnlyOutfileAppendStock.UseVisualStyleBackColor = true;
+      this.radioButtonOnlyOutfileAppendStock.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
       // 
-      // radioButtonSummaryStockDistNoAux
+      // radioButtonOnlyOutfileNoStock
       // 
-      this.radioButtonSummaryStockDistNoAux.AutoSize = true;
-      this.radioButtonSummaryStockDistNoAux.Location = new System.Drawing.Point(17, 63);
-      this.radioButtonSummaryStockDistNoAux.Name = "radioButtonSummaryStockDistNoAux";
-      this.radioButtonSummaryStockDistNoAux.Size = new System.Drawing.Size(220, 17);
-      this.radioButtonSummaryStockDistNoAux.TabIndex = 2;
-      this.radioButtonSummaryStockDistNoAux.TabStop = true;
-      this.radioButtonSummaryStockDistNoAux.Text = "Stock Distribution Only (No Auxiliary Files)";
-      this.radioButtonSummaryStockDistNoAux.UseVisualStyleBackColor = true;
-      this.radioButtonSummaryStockDistNoAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryNoAux1_CheckedChanged);
+      this.radioButtonOnlyOutfileNoStock.AutoSize = true;
+      this.radioButtonOnlyOutfileNoStock.Location = new System.Drawing.Point(17, 63);
+      this.radioButtonOnlyOutfileNoStock.Name = "radioButtonOnlyOutfileNoStock";
+      this.radioButtonOnlyOutfileNoStock.Size = new System.Drawing.Size(224, 17);
+      this.radioButtonOnlyOutfileNoStock.TabIndex = 2;
+      this.radioButtonOnlyOutfileNoStock.TabStop = true;
+      this.radioButtonOnlyOutfileNoStock.Text = "ONLY Output File (NO Stock Distributions)";
+      this.radioButtonOnlyOutfileNoStock.UseVisualStyleBackColor = true;
+      this.radioButtonOnlyOutfileNoStock.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryNoAux1_CheckedChanged);
       // 
-      // radioButtonStockDistAllAux
+      // radioButtonOutfileAppendStockAllAux
       // 
-      this.radioButtonStockDistAllAux.AutoSize = true;
-      this.radioButtonStockDistAllAux.Location = new System.Drawing.Point(17, 40);
-      this.radioButtonStockDistAllAux.Name = "radioButtonStockDistAllAux";
-      this.radioButtonStockDistAllAux.Size = new System.Drawing.Size(197, 17);
-      this.radioButtonStockDistAllAux.TabIndex = 1;
-      this.radioButtonStockDistAllAux.TabStop = true;
-      this.radioButtonStockDistAllAux.Text = "Auxiliary Files and Stock Distribution ";
-      this.radioButtonStockDistAllAux.UseVisualStyleBackColor = true;
-      this.radioButtonStockDistAllAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryOnly_CheckedChanged);
+      this.radioButtonOutfileAppendStockAllAux.AutoSize = true;
+      this.radioButtonOutfileAppendStockAllAux.Location = new System.Drawing.Point(17, 40);
+      this.radioButtonOutfileAppendStockAllAux.Name = "radioButtonOutfileAppendStockAllAux";
+      this.radioButtonOutfileAppendStockAllAux.Size = new System.Drawing.Size(273, 17);
+      this.radioButtonOutfileAppendStockAllAux.TabIndex = 1;
+      this.radioButtonOutfileAppendStockAllAux.TabStop = true;
+      this.radioButtonOutfileAppendStockAllAux.Text = "Output file with Stock Distributions, ALL Auxiliary files";
+      this.radioButtonOutfileAppendStockAllAux.UseVisualStyleBackColor = true;
+      this.radioButtonOutfileAppendStockAllAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryOnly_CheckedChanged);
       // 
-      // radioButtonNoStockDistAllAux
+      // radioButtonOutfileNoStockExcludeStockAux
       // 
-      this.radioButtonNoStockDistAllAux.AutoSize = true;
-      this.radioButtonNoStockDistAllAux.Location = new System.Drawing.Point(17, 17);
-      this.radioButtonNoStockDistAllAux.Name = "radioButtonNoStockDistAllAux";
-      this.radioButtonNoStockDistAllAux.Size = new System.Drawing.Size(220, 17);
-      this.radioButtonNoStockDistAllAux.TabIndex = 0;
-      this.radioButtonNoStockDistAllAux.TabStop = true;
-      this.radioButtonNoStockDistAllAux.Text = "Auxiliary Files Only (No Stock Distribution)";
-      this.radioButtonNoStockDistAllAux.UseVisualStyleBackColor = true;
-      this.radioButtonNoStockDistAllAux.CheckedChanged += new System.EventHandler(this.RadioButtonNone_CheckedChanged);
+      this.radioButtonOutfileNoStockExcludeStockAux.AutoSize = true;
+      this.radioButtonOutfileNoStockExcludeStockAux.Location = new System.Drawing.Point(17, 17);
+      this.radioButtonOutfileNoStockExcludeStockAux.Name = "radioButtonOutfileNoStockExcludeStockAux";
+      this.radioButtonOutfileNoStockExcludeStockAux.Size = new System.Drawing.Size(376, 17);
+      this.radioButtonOutfileNoStockExcludeStockAux.TabIndex = 0;
+      this.radioButtonOutfileNoStockExcludeStockAux.TabStop = true;
+      this.radioButtonOutfileNoStockExcludeStockAux.Text = "Output file without Stock Distributions, Auxiliary files EXCEPT Stock of Age";
+      this.radioButtonOutfileNoStockExcludeStockAux.UseVisualStyleBackColor = true;
+      this.radioButtonOutfileNoStockExcludeStockAux.CheckedChanged += new System.EventHandler(this.RadioButtonNone_CheckedChanged);
       // 
       // groupOutputViewer
       // 
       this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
       this.groupOutputViewer.Controls.Add(this.labelOutputViewerProgram);
-      this.groupOutputViewer.Location = new System.Drawing.Point(418, 15);
+      this.groupOutputViewer.Location = new System.Drawing.Point(441, 15);
       this.groupOutputViewer.Name = "groupOutputViewer";
       this.groupOutputViewer.Size = new System.Drawing.Size(390, 65);
       this.groupOutputViewer.TabIndex = 3;
       this.groupOutputViewer.TabStop = false;
       this.groupOutputViewer.Text = "Output File Viewer";
+      // 
+      // radioButtonOutfileAppendStockExcludeStockAux
+      // 
+      this.radioButtonOutfileAppendStockExcludeStockAux.AutoSize = true;
+      this.radioButtonOutfileAppendStockExcludeStockAux.Location = new System.Drawing.Point(17, 109);
+      this.radioButtonOutfileAppendStockExcludeStockAux.Name = "radioButtonOutfileAppendStockExcludeStockAux";
+      this.radioButtonOutfileAppendStockExcludeStockAux.Size = new System.Drawing.Size(367, 17);
+      this.radioButtonOutfileAppendStockExcludeStockAux.TabIndex = 4;
+      this.radioButtonOutfileAppendStockExcludeStockAux.TabStop = true;
+      this.radioButtonOutfileAppendStockExcludeStockAux.Text = "Output File with Stock Distributions, Auxiliary Files EXCEPT Stock of Age";
+      this.radioButtonOutfileAppendStockExcludeStockAux.UseVisualStyleBackColor = true;
+      this.radioButtonOutfileAppendStockExcludeStockAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
       // 
       // dataGridRetroAdjustment
       // 
@@ -624,10 +638,11 @@
         private System.Windows.Forms.ComboBox comboBoxOutputViewerProgram;
         private System.Windows.Forms.Label labelOutputViewerProgram;
     private System.Windows.Forms.GroupBox groupBox_StockSummmaryFlag;
-    private System.Windows.Forms.RadioButton radioButtonNoStockDistAllAux;
-    private System.Windows.Forms.RadioButton radioButtonSummaryStockDistNoAux;
-    private System.Windows.Forms.RadioButton radioButtonStockDistAllAux;
-    private System.Windows.Forms.RadioButton radioButtonStockDistExceptAuxStockVector;
+    private System.Windows.Forms.RadioButton radioButtonOutfileNoStockExcludeStockAux;
+    private System.Windows.Forms.RadioButton radioButtonOnlyOutfileNoStock;
+    private System.Windows.Forms.RadioButton radioButtonOutfileAppendStockAllAux;
+    private System.Windows.Forms.RadioButton radioButtonOnlyOutfileAppendStock;
     private System.Windows.Forms.GroupBox groupOutputViewer;
+    private System.Windows.Forms.RadioButton radioButtonOutfileAppendStockExcludeStockAux;
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -35,32 +35,22 @@
       this.checkBoxEnableExportR = new System.Windows.Forms.CheckBox();
       this.checkBoxEnableAuxStochasticFiles = new System.Windows.Forms.CheckBox();
       this.groupRefpoints = new System.Windows.Forms.GroupBox();
-      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelFishMortality = new System.Windows.Forms.Label();
-      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.checkBoxEnableRefpoints = new System.Windows.Forms.CheckBox();
       this.labelMeanBiomass = new System.Windows.Forms.Label();
-      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelJan1Biomass = new System.Windows.Forms.Label();
-      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelSpawnBiomass = new System.Windows.Forms.Label();
       this.groupBounds = new System.Windows.Forms.GroupBox();
-      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsNatMortality = new System.Windows.Forms.Label();
-      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsMaxWeight = new System.Windows.Forms.Label();
       this.checkBoxBounds = new System.Windows.Forms.CheckBox();
       this.groupScaleFactors = new System.Windows.Forms.GroupBox();
-      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorRecruits = new System.Windows.Forms.Label();
-      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorStockNum = new System.Windows.Forms.Label();
-      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorBiomass = new System.Windows.Forms.Label();
       this.checkBoxEnableScaleFactors = new System.Windows.Forms.CheckBox();
       this.groupRetroAdjustment = new System.Windows.Forms.GroupBox();
       this.checkBoxEnableRetroAdjustment = new System.Windows.Forms.CheckBox();
-      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
       this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
@@ -71,15 +61,26 @@
       this.radioButtonNoStockAge_ExcludeStockNumAux = new System.Windows.Forms.RadioButton();
       this.groupOutputViewer = new System.Windows.Forms.GroupBox();
       this.checkBoxEnableVer40Format = new System.Windows.Forms.CheckBox();
+      this.textBoxMiscOptionsInpfileVerString = new Nmfs.Agepro.Gui.NftTextBox();
+      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
+      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.groupOuputOptions.SuspendLayout();
       ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).BeginInit();
       this.groupRefpoints.SuspendLayout();
       this.groupBounds.SuspendLayout();
       this.groupScaleFactors.SuspendLayout();
       this.groupRetroAdjustment.SuspendLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.groupBox_StockSummmaryFlag.SuspendLayout();
       this.groupOutputViewer.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.SuspendLayout();
       // 
       // groupOuputOptions
@@ -89,11 +90,9 @@
       this.groupOuputOptions.Controls.Add(this.checkBoxEnablePercentileReport);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableExportR);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableAuxStochasticFiles);
-      this.groupOuputOptions.Location = new System.Drawing.Point(39, 190);
-      this.groupOuputOptions.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupOuputOptions.Location = new System.Drawing.Point(29, 154);
       this.groupOuputOptions.Name = "groupOuputOptions";
-      this.groupOuputOptions.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.groupOuputOptions.Size = new System.Drawing.Size(541, 151);
+      this.groupOuputOptions.Size = new System.Drawing.Size(406, 123);
       this.groupOuputOptions.TabIndex = 1;
       this.groupOuputOptions.TabStop = false;
       this.groupOuputOptions.Text = "Output Options";
@@ -102,30 +101,27 @@
       // 
       this.spinBoxReportPercentile.DecimalPlaces = 1;
       this.spinBoxReportPercentile.Enabled = false;
-      this.spinBoxReportPercentile.Location = new System.Drawing.Point(212, 108);
-      this.spinBoxReportPercentile.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.spinBoxReportPercentile.Location = new System.Drawing.Point(159, 88);
       this.spinBoxReportPercentile.Name = "spinBoxReportPercentile";
-      this.spinBoxReportPercentile.Size = new System.Drawing.Size(143, 22);
+      this.spinBoxReportPercentile.Size = new System.Drawing.Size(107, 20);
       this.spinBoxReportPercentile.TabIndex = 5;
       // 
       // labelReportPercentile
       // 
       this.labelReportPercentile.AutoSize = true;
       this.labelReportPercentile.Enabled = false;
-      this.labelReportPercentile.Location = new System.Drawing.Point(85, 111);
-      this.labelReportPercentile.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelReportPercentile.Location = new System.Drawing.Point(64, 90);
       this.labelReportPercentile.Name = "labelReportPercentile";
-      this.labelReportPercentile.Size = new System.Drawing.Size(111, 16);
+      this.labelReportPercentile.Size = new System.Drawing.Size(89, 13);
       this.labelReportPercentile.TabIndex = 4;
       this.labelReportPercentile.Text = "Report Percentile";
       // 
       // checkBoxEnablePercentileReport
       // 
       this.checkBoxEnablePercentileReport.AutoSize = true;
-      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(23, 81);
-      this.checkBoxEnablePercentileReport.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(17, 66);
       this.checkBoxEnablePercentileReport.Name = "checkBoxEnablePercentileReport";
-      this.checkBoxEnablePercentileReport.Size = new System.Drawing.Size(187, 20);
+      this.checkBoxEnablePercentileReport.Size = new System.Drawing.Size(151, 17);
       this.checkBoxEnablePercentileReport.TabIndex = 3;
       this.checkBoxEnablePercentileReport.Text = "Request Percentile Report";
       this.checkBoxEnablePercentileReport.UseVisualStyleBackColor = true;
@@ -134,10 +130,9 @@
       // checkBoxEnableExportR
       // 
       this.checkBoxEnableExportR.AutoSize = true;
-      this.checkBoxEnableExportR.Location = new System.Drawing.Point(23, 53);
-      this.checkBoxEnableExportR.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxEnableExportR.Location = new System.Drawing.Point(17, 43);
       this.checkBoxEnableExportR.Name = "checkBoxEnableExportR";
-      this.checkBoxEnableExportR.Size = new System.Drawing.Size(142, 20);
+      this.checkBoxEnableExportR.Size = new System.Drawing.Size(117, 17);
       this.checkBoxEnableExportR.TabIndex = 2;
       this.checkBoxEnableExportR.Text = "Export Results to R";
       this.checkBoxEnableExportR.UseVisualStyleBackColor = true;
@@ -145,10 +140,9 @@
       // checkBoxEnableAuxStochasticFiles
       // 
       this.checkBoxEnableAuxStochasticFiles.AutoSize = true;
-      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(23, 25);
-      this.checkBoxEnableAuxStochasticFiles.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(17, 20);
       this.checkBoxEnableAuxStochasticFiles.Name = "checkBoxEnableAuxStochasticFiles";
-      this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(267, 20);
+      this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(214, 17);
       this.checkBoxEnableAuxStochasticFiles.TabIndex = 4;
       this.checkBoxEnableAuxStochasticFiles.Text = "Generate Auxiliary Stochastic Data Files";
       this.checkBoxEnableAuxStochasticFiles.UseVisualStyleBackColor = true;
@@ -164,55 +158,29 @@
       this.groupRefpoints.Controls.Add(this.labelJan1Biomass);
       this.groupRefpoints.Controls.Add(this.textBoxRefSpawnBiomass);
       this.groupRefpoints.Controls.Add(this.labelSpawnBiomass);
-      this.groupRefpoints.Location = new System.Drawing.Point(588, 270);
-      this.groupRefpoints.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupRefpoints.Location = new System.Drawing.Point(441, 219);
       this.groupRefpoints.Name = "groupRefpoints";
-      this.groupRefpoints.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.groupRefpoints.Size = new System.Drawing.Size(520, 187);
+      this.groupRefpoints.Size = new System.Drawing.Size(390, 152);
       this.groupRefpoints.TabIndex = 5;
       this.groupRefpoints.TabStop = false;
       this.groupRefpoints.Text = "Reference Points";
-      // 
-      // textBoxRefFishMortality
-      // 
-      this.textBoxRefFishMortality.Enabled = false;
-      this.textBoxRefFishMortality.Location = new System.Drawing.Point(252, 148);
-      this.textBoxRefFishMortality.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
-      this.textBoxRefFishMortality.ParamName = null;
-      this.textBoxRefFishMortality.PrevValidValue = "";
-      this.textBoxRefFishMortality.Size = new System.Drawing.Size(155, 22);
-      this.textBoxRefFishMortality.TabIndex = 8;
       // 
       // labelFishMortality
       // 
       this.labelFishMortality.AutoSize = true;
       this.labelFishMortality.Enabled = false;
-      this.labelFishMortality.Location = new System.Drawing.Point(25, 151);
-      this.labelFishMortality.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelFishMortality.Location = new System.Drawing.Point(19, 123);
       this.labelFishMortality.Name = "labelFishMortality";
-      this.labelFishMortality.Size = new System.Drawing.Size(103, 16);
+      this.labelFishMortality.Size = new System.Drawing.Size(82, 13);
       this.labelFishMortality.TabIndex = 7;
       this.labelFishMortality.Text = "Fishing Mortality";
-      // 
-      // textBoxRefMeanBiomass
-      // 
-      this.textBoxRefMeanBiomass.Enabled = false;
-      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(252, 116);
-      this.textBoxRefMeanBiomass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
-      this.textBoxRefMeanBiomass.ParamName = null;
-      this.textBoxRefMeanBiomass.PrevValidValue = "";
-      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(155, 22);
-      this.textBoxRefMeanBiomass.TabIndex = 6;
       // 
       // checkBoxEnableRefpoints
       // 
       this.checkBoxEnableRefpoints.AutoSize = true;
-      this.checkBoxEnableRefpoints.Location = new System.Drawing.Point(29, 23);
-      this.checkBoxEnableRefpoints.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxEnableRefpoints.Location = new System.Drawing.Point(22, 19);
       this.checkBoxEnableRefpoints.Name = "checkBoxEnableRefpoints";
-      this.checkBoxEnableRefpoints.Size = new System.Drawing.Size(279, 20);
+      this.checkBoxEnableRefpoints.Size = new System.Drawing.Size(224, 17);
       this.checkBoxEnableRefpoints.TabIndex = 0;
       this.checkBoxEnableRefpoints.Text = "Enable Reference Point Threshold Report";
       this.checkBoxEnableRefpoints.UseVisualStyleBackColor = true;
@@ -222,54 +190,29 @@
       // 
       this.labelMeanBiomass.AutoSize = true;
       this.labelMeanBiomass.Enabled = false;
-      this.labelMeanBiomass.Location = new System.Drawing.Point(25, 119);
-      this.labelMeanBiomass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelMeanBiomass.Location = new System.Drawing.Point(19, 97);
       this.labelMeanBiomass.Name = "labelMeanBiomass";
-      this.labelMeanBiomass.Size = new System.Drawing.Size(128, 16);
+      this.labelMeanBiomass.Size = new System.Drawing.Size(101, 13);
       this.labelMeanBiomass.TabIndex = 5;
       this.labelMeanBiomass.Text = "Mean Biomass (MT)";
-      // 
-      // textBoxRefJan1Biomass
-      // 
-      this.textBoxRefJan1Biomass.Enabled = false;
-      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(252, 84);
-      this.textBoxRefJan1Biomass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
-      this.textBoxRefJan1Biomass.ParamName = null;
-      this.textBoxRefJan1Biomass.PrevValidValue = "";
-      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(155, 22);
-      this.textBoxRefJan1Biomass.TabIndex = 4;
       // 
       // labelJan1Biomass
       // 
       this.labelJan1Biomass.AutoSize = true;
       this.labelJan1Biomass.Enabled = false;
-      this.labelJan1Biomass.Location = new System.Drawing.Point(25, 87);
-      this.labelJan1Biomass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelJan1Biomass.Location = new System.Drawing.Point(19, 71);
       this.labelJan1Biomass.Name = "labelJan1Biomass";
-      this.labelJan1Biomass.Size = new System.Drawing.Size(164, 16);
+      this.labelJan1Biomass.Size = new System.Drawing.Size(131, 13);
       this.labelJan1Biomass.TabIndex = 3;
       this.labelJan1Biomass.Text = "Jan-1 Stock Biomass (MT)";
-      // 
-      // textBoxRefSpawnBiomass
-      // 
-      this.textBoxRefSpawnBiomass.Enabled = false;
-      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(252, 52);
-      this.textBoxRefSpawnBiomass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
-      this.textBoxRefSpawnBiomass.ParamName = null;
-      this.textBoxRefSpawnBiomass.PrevValidValue = "";
-      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(155, 22);
-      this.textBoxRefSpawnBiomass.TabIndex = 2;
       // 
       // labelSpawnBiomass
       // 
       this.labelSpawnBiomass.AutoSize = true;
       this.labelSpawnBiomass.Enabled = false;
-      this.labelSpawnBiomass.Location = new System.Drawing.Point(25, 55);
-      this.labelSpawnBiomass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelSpawnBiomass.Location = new System.Drawing.Point(19, 45);
       this.labelSpawnBiomass.Name = "labelSpawnBiomass";
-      this.labelSpawnBiomass.Size = new System.Drawing.Size(190, 16);
+      this.labelSpawnBiomass.Size = new System.Drawing.Size(152, 13);
       this.labelSpawnBiomass.TabIndex = 1;
       this.labelSpawnBiomass.Text = "Spawning Stock Biomass (MT)";
       // 
@@ -280,68 +223,39 @@
       this.groupBounds.Controls.Add(this.textBoxBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.labelBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.checkBoxBounds);
-      this.groupBounds.Location = new System.Drawing.Point(588, 140);
-      this.groupBounds.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupBounds.Location = new System.Drawing.Point(441, 114);
       this.groupBounds.Name = "groupBounds";
-      this.groupBounds.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.groupBounds.Size = new System.Drawing.Size(520, 122);
+      this.groupBounds.Size = new System.Drawing.Size(390, 99);
       this.groupBounds.TabIndex = 4;
       this.groupBounds.TabStop = false;
       this.groupBounds.Text = "Bounds";
-      // 
-      // textBoxBoundsNatMortality
-      // 
-      this.textBoxBoundsNatMortality.Enabled = false;
-      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(211, 84);
-      this.textBoxBoundsNatMortality.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
-      this.textBoxBoundsNatMortality.ParamName = null;
-      this.textBoxBoundsNatMortality.PrevValidValue = "";
-      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(132, 22);
-      this.textBoxBoundsNatMortality.TabIndex = 4;
-      this.textBoxBoundsNatMortality.Text = "1.0";
       // 
       // labelBoundsNatMortality
       // 
       this.labelBoundsNatMortality.AutoSize = true;
       this.labelBoundsNatMortality.Enabled = false;
-      this.labelBoundsNatMortality.Location = new System.Drawing.Point(20, 87);
-      this.labelBoundsNatMortality.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelBoundsNatMortality.Location = new System.Drawing.Point(15, 71);
       this.labelBoundsNatMortality.Name = "labelBoundsNatMortality";
-      this.labelBoundsNatMortality.Size = new System.Drawing.Size(163, 16);
+      this.labelBoundsNatMortality.Size = new System.Drawing.Size(130, 13);
       this.labelBoundsNatMortality.TabIndex = 3;
       this.labelBoundsNatMortality.Text = "Maximum Natural Mortality";
-      // 
-      // textBoxBoundsMaxWeight
-      // 
-      this.textBoxBoundsMaxWeight.Enabled = false;
-      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(211, 52);
-      this.textBoxBoundsMaxWeight.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
-      this.textBoxBoundsMaxWeight.ParamName = null;
-      this.textBoxBoundsMaxWeight.PrevValidValue = "";
-      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(132, 22);
-      this.textBoxBoundsMaxWeight.TabIndex = 2;
-      this.textBoxBoundsMaxWeight.Text = "10.0";
       // 
       // labelBoundsMaxWeight
       // 
       this.labelBoundsMaxWeight.AutoSize = true;
       this.labelBoundsMaxWeight.Enabled = false;
-      this.labelBoundsMaxWeight.Location = new System.Drawing.Point(20, 55);
-      this.labelBoundsMaxWeight.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelBoundsMaxWeight.Location = new System.Drawing.Point(15, 45);
       this.labelBoundsMaxWeight.Name = "labelBoundsMaxWeight";
-      this.labelBoundsMaxWeight.Size = new System.Drawing.Size(135, 16);
+      this.labelBoundsMaxWeight.Size = new System.Drawing.Size(109, 13);
       this.labelBoundsMaxWeight.TabIndex = 1;
       this.labelBoundsMaxWeight.Text = "Maximum Weight (kg)";
       // 
       // checkBoxBounds
       // 
       this.checkBoxBounds.AutoSize = true;
-      this.checkBoxBounds.Location = new System.Drawing.Point(24, 23);
-      this.checkBoxBounds.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxBounds.Location = new System.Drawing.Point(18, 19);
       this.checkBoxBounds.Name = "checkBoxBounds";
-      this.checkBoxBounds.Size = new System.Drawing.Size(123, 20);
+      this.checkBoxBounds.Size = new System.Drawing.Size(100, 17);
       this.checkBoxBounds.TabIndex = 0;
       this.checkBoxBounds.Text = "Specify Bounds";
       this.checkBoxBounds.UseVisualStyleBackColor = true;
@@ -356,88 +270,49 @@
       this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.labelScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.checkBoxEnableScaleFactors);
-      this.groupScaleFactors.Location = new System.Drawing.Point(588, 464);
-      this.groupScaleFactors.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupScaleFactors.Location = new System.Drawing.Point(441, 377);
       this.groupScaleFactors.Name = "groupScaleFactors";
-      this.groupScaleFactors.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.groupScaleFactors.Size = new System.Drawing.Size(520, 158);
+      this.groupScaleFactors.Size = new System.Drawing.Size(390, 128);
       this.groupScaleFactors.TabIndex = 6;
       this.groupScaleFactors.TabStop = false;
       this.groupScaleFactors.Text = "Scaling Factors for Output Report";
-      // 
-      // textBoxScaleFactorRecruits
-      // 
-      this.textBoxScaleFactorRecruits.Enabled = false;
-      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(195, 85);
-      this.textBoxScaleFactorRecruits.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
-      this.textBoxScaleFactorRecruits.ParamName = null;
-      this.textBoxScaleFactorRecruits.PrevValidValue = "";
-      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(132, 22);
-      this.textBoxScaleFactorRecruits.TabIndex = 4;
       // 
       // labelScaleFactorRecruits
       // 
       this.labelScaleFactorRecruits.AutoSize = true;
       this.labelScaleFactorRecruits.Enabled = false;
-      this.labelScaleFactorRecruits.Location = new System.Drawing.Point(29, 89);
-      this.labelScaleFactorRecruits.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelScaleFactorRecruits.Location = new System.Drawing.Point(22, 72);
       this.labelScaleFactorRecruits.Name = "labelScaleFactorRecruits";
-      this.labelScaleFactorRecruits.Size = new System.Drawing.Size(56, 16);
+      this.labelScaleFactorRecruits.Size = new System.Drawing.Size(46, 13);
       this.labelScaleFactorRecruits.TabIndex = 3;
       this.labelScaleFactorRecruits.Text = "Recruits";
-      // 
-      // textBoxScaleFactorsStockNum
-      // 
-      this.textBoxScaleFactorsStockNum.Enabled = false;
-      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(195, 117);
-      this.textBoxScaleFactorsStockNum.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
-      this.textBoxScaleFactorsStockNum.ParamName = null;
-      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
-      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(132, 22);
-      this.textBoxScaleFactorsStockNum.TabIndex = 6;
       // 
       // labelScaleFactorStockNum
       // 
       this.labelScaleFactorStockNum.AutoSize = true;
       this.labelScaleFactorStockNum.Enabled = false;
-      this.labelScaleFactorStockNum.Location = new System.Drawing.Point(28, 121);
-      this.labelScaleFactorStockNum.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelScaleFactorStockNum.Location = new System.Drawing.Point(21, 98);
       this.labelScaleFactorStockNum.Name = "labelScaleFactorStockNum";
-      this.labelScaleFactorStockNum.Size = new System.Drawing.Size(99, 16);
+      this.labelScaleFactorStockNum.Size = new System.Drawing.Size(80, 13);
       this.labelScaleFactorStockNum.TabIndex = 5;
       this.labelScaleFactorStockNum.Text = "Stock Numbers";
-      // 
-      // textBoxScaleFactorBiomass
-      // 
-      this.textBoxScaleFactorBiomass.Enabled = false;
-      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(195, 53);
-      this.textBoxScaleFactorBiomass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
-      this.textBoxScaleFactorBiomass.ParamName = null;
-      this.textBoxScaleFactorBiomass.PrevValidValue = "";
-      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(132, 22);
-      this.textBoxScaleFactorBiomass.TabIndex = 2;
       // 
       // labelScaleFactorBiomass
       // 
       this.labelScaleFactorBiomass.AutoSize = true;
       this.labelScaleFactorBiomass.Enabled = false;
-      this.labelScaleFactorBiomass.Location = new System.Drawing.Point(29, 57);
-      this.labelScaleFactorBiomass.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelScaleFactorBiomass.Location = new System.Drawing.Point(22, 46);
       this.labelScaleFactorBiomass.Name = "labelScaleFactorBiomass";
-      this.labelScaleFactorBiomass.Size = new System.Drawing.Size(60, 16);
+      this.labelScaleFactorBiomass.Size = new System.Drawing.Size(46, 13);
       this.labelScaleFactorBiomass.TabIndex = 1;
       this.labelScaleFactorBiomass.Text = "Biomass";
       // 
       // checkBoxEnableScaleFactors
       // 
       this.checkBoxEnableScaleFactors.AutoSize = true;
-      this.checkBoxEnableScaleFactors.Location = new System.Drawing.Point(29, 25);
-      this.checkBoxEnableScaleFactors.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxEnableScaleFactors.Location = new System.Drawing.Point(22, 20);
       this.checkBoxEnableScaleFactors.Name = "checkBoxEnableScaleFactors";
-      this.checkBoxEnableScaleFactors.Size = new System.Drawing.Size(288, 20);
+      this.checkBoxEnableScaleFactors.Size = new System.Drawing.Size(233, 17);
       this.checkBoxEnableScaleFactors.TabIndex = 0;
       this.checkBoxEnableScaleFactors.Text = "Specify Scale Factors for Output Report File";
       this.checkBoxEnableScaleFactors.UseVisualStyleBackColor = true;
@@ -447,11 +322,9 @@
       // 
       this.groupRetroAdjustment.Controls.Add(this.checkBoxEnableRetroAdjustment);
       this.groupRetroAdjustment.Controls.Add(this.dataGridRetroAdjustment);
-      this.groupRetroAdjustment.Location = new System.Drawing.Point(39, 348);
-      this.groupRetroAdjustment.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupRetroAdjustment.Location = new System.Drawing.Point(29, 283);
       this.groupRetroAdjustment.Name = "groupRetroAdjustment";
-      this.groupRetroAdjustment.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.groupRetroAdjustment.Size = new System.Drawing.Size(541, 274);
+      this.groupRetroAdjustment.Size = new System.Drawing.Size(406, 223);
       this.groupRetroAdjustment.TabIndex = 2;
       this.groupRetroAdjustment.TabStop = false;
       this.groupRetroAdjustment.Text = "Retrospective Adjustment Factors";
@@ -459,31 +332,13 @@
       // checkBoxEnableRetroAdjustment
       // 
       this.checkBoxEnableRetroAdjustment.AutoSize = true;
-      this.checkBoxEnableRetroAdjustment.Location = new System.Drawing.Point(23, 25);
-      this.checkBoxEnableRetroAdjustment.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxEnableRetroAdjustment.Location = new System.Drawing.Point(17, 20);
       this.checkBoxEnableRetroAdjustment.Name = "checkBoxEnableRetroAdjustment";
-      this.checkBoxEnableRetroAdjustment.Size = new System.Drawing.Size(278, 20);
+      this.checkBoxEnableRetroAdjustment.Size = new System.Drawing.Size(223, 17);
       this.checkBoxEnableRetroAdjustment.TabIndex = 1;
       this.checkBoxEnableRetroAdjustment.Text = "Specify Retrospective Adjustment Factors";
       this.checkBoxEnableRetroAdjustment.UseVisualStyleBackColor = true;
       this.checkBoxEnableRetroAdjustment.CheckedChanged += new System.EventHandler(this.CheckBoxRetroAdjustment_CheckedChanged);
-      // 
-      // dataGridRetroAdjustment
-      // 
-      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
-      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
-      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
-      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
-      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
-      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(23, 49);
-      this.dataGridRetroAdjustment.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
-      this.dataGridRetroAdjustment.nftReadOnly = false;
-      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
-      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(475, 210);
-      this.dataGridRetroAdjustment.TabIndex = 0;
-      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
       // 
       // comboBoxOutputViewerProgram
       // 
@@ -492,19 +347,17 @@
             "System Default",
             "Notepad",
             "None"});
-      this.comboBoxOutputViewerProgram.Location = new System.Drawing.Point(24, 39);
-      this.comboBoxOutputViewerProgram.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.comboBoxOutputViewerProgram.Location = new System.Drawing.Point(18, 32);
       this.comboBoxOutputViewerProgram.Name = "comboBoxOutputViewerProgram";
-      this.comboBoxOutputViewerProgram.Size = new System.Drawing.Size(451, 24);
+      this.comboBoxOutputViewerProgram.Size = new System.Drawing.Size(339, 21);
       this.comboBoxOutputViewerProgram.TabIndex = 1;
       // 
       // labelOutputViewerProgram
       // 
       this.labelOutputViewerProgram.AutoSize = true;
-      this.labelOutputViewerProgram.Location = new System.Drawing.Point(20, 20);
-      this.labelOutputViewerProgram.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+      this.labelOutputViewerProgram.Location = new System.Drawing.Point(15, 16);
       this.labelOutputViewerProgram.Name = "labelOutputViewerProgram";
-      this.labelOutputViewerProgram.Size = new System.Drawing.Size(234, 16);
+      this.labelOutputViewerProgram.Size = new System.Drawing.Size(189, 13);
       this.labelOutputViewerProgram.TabIndex = 0;
       this.labelOutputViewerProgram.Text = "Program to View AGEPRO Output File ";
       // 
@@ -515,11 +368,9 @@
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockAge_NoAux);
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockAge_AllAux);
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockAge_ExcludeStockNumAux);
-      this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(39, 18);
-      this.groupBox_StockSummmaryFlag.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
       this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
-      this.groupBox_StockSummmaryFlag.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(541, 164);
+      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(406, 133);
       this.groupBox_StockSummmaryFlag.TabIndex = 0;
       this.groupBox_StockSummmaryFlag.TabStop = false;
       this.groupBox_StockSummmaryFlag.Text = "Stock Distribution Summary and Auxiliary Data Files";
@@ -527,10 +378,9 @@
       // radioButtonStockAge_ExcludeStockNumAux
       // 
       this.radioButtonStockAge_ExcludeStockNumAux.AutoSize = true;
-      this.radioButtonStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(23, 134);
-      this.radioButtonStockAge_ExcludeStockNumAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.radioButtonStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 109);
       this.radioButtonStockAge_ExcludeStockNumAux.Name = "radioButtonStockAge_ExcludeStockNumAux";
-      this.radioButtonStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(370, 20);
+      this.radioButtonStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(302, 17);
       this.radioButtonStockAge_ExcludeStockNumAux.TabIndex = 4;
       this.radioButtonStockAge_ExcludeStockNumAux.TabStop = true;
       this.radioButtonStockAge_ExcludeStockNumAux.Text = "Output Stock Of Age, Auxiliary Files EXCEPT Stock of Age";
@@ -540,10 +390,9 @@
       // radioButtonStockAge_NoAux
       // 
       this.radioButtonStockAge_NoAux.AutoSize = true;
-      this.radioButtonStockAge_NoAux.Location = new System.Drawing.Point(23, 106);
-      this.radioButtonStockAge_NoAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.radioButtonStockAge_NoAux.Location = new System.Drawing.Point(17, 86);
       this.radioButtonStockAge_NoAux.Name = "radioButtonStockAge_NoAux";
-      this.radioButtonStockAge_NoAux.Size = new System.Drawing.Size(258, 20);
+      this.radioButtonStockAge_NoAux.Size = new System.Drawing.Size(211, 17);
       this.radioButtonStockAge_NoAux.TabIndex = 3;
       this.radioButtonStockAge_NoAux.TabStop = true;
       this.radioButtonStockAge_NoAux.Text = "Ouptut Stock Of Age, NO Auxiilary Files";
@@ -553,10 +402,9 @@
       // radioButtonNoStockAge_NoAux
       // 
       this.radioButtonNoStockAge_NoAux.AutoSize = true;
-      this.radioButtonNoStockAge_NoAux.Location = new System.Drawing.Point(23, 78);
-      this.radioButtonNoStockAge_NoAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.radioButtonNoStockAge_NoAux.Location = new System.Drawing.Point(17, 63);
       this.radioButtonNoStockAge_NoAux.Name = "radioButtonNoStockAge_NoAux";
-      this.radioButtonNoStockAge_NoAux.Size = new System.Drawing.Size(240, 20);
+      this.radioButtonNoStockAge_NoAux.Size = new System.Drawing.Size(194, 17);
       this.radioButtonNoStockAge_NoAux.TabIndex = 2;
       this.radioButtonNoStockAge_NoAux.TabStop = true;
       this.radioButtonNoStockAge_NoAux.Text = "NO Stock Of Age and Auxiliary Files";
@@ -566,10 +414,9 @@
       // radioButtonStockAge_AllAux
       // 
       this.radioButtonStockAge_AllAux.AutoSize = true;
-      this.radioButtonStockAge_AllAux.Location = new System.Drawing.Point(23, 49);
-      this.radioButtonStockAge_AllAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.radioButtonStockAge_AllAux.Location = new System.Drawing.Point(17, 40);
       this.radioButtonStockAge_AllAux.Name = "radioButtonStockAge_AllAux";
-      this.radioButtonStockAge_AllAux.Size = new System.Drawing.Size(285, 20);
+      this.radioButtonStockAge_AllAux.Size = new System.Drawing.Size(234, 17);
       this.radioButtonStockAge_AllAux.TabIndex = 1;
       this.radioButtonStockAge_AllAux.TabStop = true;
       this.radioButtonStockAge_AllAux.Text = "Output Stock Of Age AND ALL Auxiliary files";
@@ -579,10 +426,9 @@
       // radioButtonNoStockAge_ExcludeStockNumAux
       // 
       this.radioButtonNoStockAge_ExcludeStockNumAux.AutoSize = true;
-      this.radioButtonNoStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(23, 21);
-      this.radioButtonNoStockAge_ExcludeStockNumAux.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 17);
       this.radioButtonNoStockAge_ExcludeStockNumAux.Name = "radioButtonNoStockAge_ExcludeStockNumAux";
-      this.radioButtonNoStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(442, 20);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(359, 17);
       this.radioButtonNoStockAge_ExcludeStockNumAux.TabIndex = 0;
       this.radioButtonNoStockAge_ExcludeStockNumAux.TabStop = true;
       this.radioButtonNoStockAge_ExcludeStockNumAux.Text = "No Stock of Age, Output Auxiliary files EXCEPT Stock Numbers of Age";
@@ -593,11 +439,9 @@
       // 
       this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
       this.groupOutputViewer.Controls.Add(this.labelOutputViewerProgram);
-      this.groupOutputViewer.Location = new System.Drawing.Point(588, 55);
-      this.groupOutputViewer.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.groupOutputViewer.Location = new System.Drawing.Point(441, 45);
       this.groupOutputViewer.Name = "groupOutputViewer";
-      this.groupOutputViewer.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
-      this.groupOutputViewer.Size = new System.Drawing.Size(520, 80);
+      this.groupOutputViewer.Size = new System.Drawing.Size(390, 65);
       this.groupOutputViewer.TabIndex = 3;
       this.groupOutputViewer.TabStop = false;
       this.groupOutputViewer.Text = "Output File Viewer";
@@ -605,19 +449,141 @@
       // checkBoxEnableVer40Format
       // 
       this.checkBoxEnableVer40Format.AutoSize = true;
-      this.checkBoxEnableVer40Format.Location = new System.Drawing.Point(589, 27);
-      this.checkBoxEnableVer40Format.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+      this.checkBoxEnableVer40Format.Location = new System.Drawing.Point(442, 22);
       this.checkBoxEnableVer40Format.Name = "checkBoxEnableVer40Format";
-      this.checkBoxEnableVer40Format.Size = new System.Drawing.Size(316, 20);
+      this.checkBoxEnableVer40Format.Size = new System.Drawing.Size(256, 17);
       this.checkBoxEnableVer40Format.TabIndex = 7;
       this.checkBoxEnableVer40Format.Text = "Enable AGEPRO VERSION 4.0 input File Format";
       this.checkBoxEnableVer40Format.UseVisualStyleBackColor = true;
       this.checkBoxEnableVer40Format.CheckedChanged += new System.EventHandler(this.checkBoxEnableVer40Format_CheckedChanged);
       // 
+      // textBoxMiscOptionsInpfileVerString
+      // 
+      this.textBoxMiscOptionsInpfileVerString.Anchor = System.Windows.Forms.AnchorStyles.Left;
+      this.textBoxMiscOptionsInpfileVerString.BorderStyle = System.Windows.Forms.BorderStyle.None;
+      this.textBoxMiscOptionsInpfileVerString.Enabled = false;
+      this.textBoxMiscOptionsInpfileVerString.Location = new System.Drawing.Point(704, 24);
+      this.textBoxMiscOptionsInpfileVerString.Margin = new System.Windows.Forms.Padding(3, 3, 3, 6);
+      this.textBoxMiscOptionsInpfileVerString.Name = "textBoxMiscOptionsInpfileVerString";
+      this.textBoxMiscOptionsInpfileVerString.ParamName = null;
+      this.textBoxMiscOptionsInpfileVerString.PrevValidValue = "";
+      this.textBoxMiscOptionsInpfileVerString.Size = new System.Drawing.Size(127, 13);
+      this.textBoxMiscOptionsInpfileVerString.TabIndex = 8;
+      this.textBoxMiscOptionsInpfileVerString.Text = "AGEPRO VERSION";
+      // 
+      // dataGridRetroAdjustment
+      // 
+      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
+      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
+      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
+      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
+      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
+      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(17, 40);
+      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
+      this.dataGridRetroAdjustment.nftReadOnly = false;
+      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
+      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 171);
+      this.dataGridRetroAdjustment.TabIndex = 0;
+      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
+      // 
+      // textBoxScaleFactorRecruits
+      // 
+      this.textBoxScaleFactorRecruits.Enabled = false;
+      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(146, 69);
+      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
+      this.textBoxScaleFactorRecruits.ParamName = null;
+      this.textBoxScaleFactorRecruits.PrevValidValue = "";
+      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorRecruits.TabIndex = 4;
+      // 
+      // textBoxScaleFactorsStockNum
+      // 
+      this.textBoxScaleFactorsStockNum.Enabled = false;
+      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(146, 95);
+      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
+      this.textBoxScaleFactorsStockNum.ParamName = null;
+      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
+      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorsStockNum.TabIndex = 6;
+      // 
+      // textBoxScaleFactorBiomass
+      // 
+      this.textBoxScaleFactorBiomass.Enabled = false;
+      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(146, 43);
+      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
+      this.textBoxScaleFactorBiomass.ParamName = null;
+      this.textBoxScaleFactorBiomass.PrevValidValue = "";
+      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorBiomass.TabIndex = 2;
+      // 
+      // textBoxBoundsNatMortality
+      // 
+      this.textBoxBoundsNatMortality.Enabled = false;
+      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
+      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
+      this.textBoxBoundsNatMortality.ParamName = null;
+      this.textBoxBoundsNatMortality.PrevValidValue = "";
+      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsNatMortality.TabIndex = 4;
+      this.textBoxBoundsNatMortality.Text = "1.0";
+      // 
+      // textBoxBoundsMaxWeight
+      // 
+      this.textBoxBoundsMaxWeight.Enabled = false;
+      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
+      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
+      this.textBoxBoundsMaxWeight.ParamName = null;
+      this.textBoxBoundsMaxWeight.PrevValidValue = "";
+      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsMaxWeight.TabIndex = 2;
+      this.textBoxBoundsMaxWeight.Text = "10.0";
+      // 
+      // textBoxRefFishMortality
+      // 
+      this.textBoxRefFishMortality.Enabled = false;
+      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
+      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
+      this.textBoxRefFishMortality.ParamName = null;
+      this.textBoxRefFishMortality.PrevValidValue = "";
+      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefFishMortality.TabIndex = 8;
+      // 
+      // textBoxRefMeanBiomass
+      // 
+      this.textBoxRefMeanBiomass.Enabled = false;
+      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
+      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
+      this.textBoxRefMeanBiomass.ParamName = null;
+      this.textBoxRefMeanBiomass.PrevValidValue = "";
+      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefMeanBiomass.TabIndex = 6;
+      // 
+      // textBoxRefJan1Biomass
+      // 
+      this.textBoxRefJan1Biomass.Enabled = false;
+      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
+      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
+      this.textBoxRefJan1Biomass.ParamName = null;
+      this.textBoxRefJan1Biomass.PrevValidValue = "";
+      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefJan1Biomass.TabIndex = 4;
+      // 
+      // textBoxRefSpawnBiomass
+      // 
+      this.textBoxRefSpawnBiomass.Enabled = false;
+      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
+      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
+      this.textBoxRefSpawnBiomass.ParamName = null;
+      this.textBoxRefSpawnBiomass.PrevValidValue = "";
+      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefSpawnBiomass.TabIndex = 2;
+      // 
       // ControlMiscOptions
       // 
-      this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
       this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.Controls.Add(this.textBoxMiscOptionsInpfileVerString);
       this.Controls.Add(this.checkBoxEnableVer40Format);
       this.Controls.Add(this.groupOutputViewer);
       this.Controls.Add(this.groupBox_StockSummmaryFlag);
@@ -626,9 +592,8 @@
       this.Controls.Add(this.groupBounds);
       this.Controls.Add(this.groupRefpoints);
       this.Controls.Add(this.groupOuputOptions);
-      this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
       this.Name = "ControlMiscOptions";
-      this.Size = new System.Drawing.Size(1200, 640);
+      this.Size = new System.Drawing.Size(900, 520);
       this.groupOuputOptions.ResumeLayout(false);
       this.groupOuputOptions.PerformLayout();
       ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).EndInit();
@@ -640,11 +605,11 @@
       this.groupScaleFactors.PerformLayout();
       this.groupRetroAdjustment.ResumeLayout(false);
       this.groupRetroAdjustment.PerformLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.groupBox_StockSummmaryFlag.ResumeLayout(false);
       this.groupBox_StockSummmaryFlag.PerformLayout();
       this.groupOutputViewer.ResumeLayout(false);
       this.groupOutputViewer.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.ResumeLayout(false);
       this.PerformLayout();
 
@@ -695,5 +660,6 @@
     private System.Windows.Forms.GroupBox groupOutputViewer;
     private System.Windows.Forms.RadioButton radioButtonStockAge_ExcludeStockNumAux;
     private System.Windows.Forms.CheckBox checkBoxEnableVer40Format;
+    private NftTextBox textBoxMiscOptionsInpfileVerString;
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -34,52 +34,52 @@
       this.checkBoxEnablePercentileReport = new System.Windows.Forms.CheckBox();
       this.checkBoxEnableExportR = new System.Windows.Forms.CheckBox();
       this.checkBoxEnableAuxStochasticFiles = new System.Windows.Forms.CheckBox();
-      this.checkBoxEnableSummaryReport = new System.Windows.Forms.CheckBox();
       this.groupRefpoints = new System.Windows.Forms.GroupBox();
+      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelFishMortality = new System.Windows.Forms.Label();
+      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.checkBoxEnableRefpoints = new System.Windows.Forms.CheckBox();
       this.labelMeanBiomass = new System.Windows.Forms.Label();
+      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelJan1Biomass = new System.Windows.Forms.Label();
+      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelSpawnBiomass = new System.Windows.Forms.Label();
       this.groupBounds = new System.Windows.Forms.GroupBox();
+      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsNatMortality = new System.Windows.Forms.Label();
+      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsMaxWeight = new System.Windows.Forms.Label();
       this.checkBoxBounds = new System.Windows.Forms.CheckBox();
       this.groupScaleFactors = new System.Windows.Forms.GroupBox();
+      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorRecruits = new System.Windows.Forms.Label();
+      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorStockNum = new System.Windows.Forms.Label();
+      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorBiomass = new System.Windows.Forms.Label();
       this.checkBoxEnableScaleFactors = new System.Windows.Forms.CheckBox();
       this.groupRetroAdjustment = new System.Windows.Forms.GroupBox();
       this.checkBoxEnableRetroAdjustment = new System.Windows.Forms.CheckBox();
+      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
       this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
+      this.radioButtonOutfileAppendStockExcludeStockAux = new System.Windows.Forms.RadioButton();
       this.radioButtonOnlyOutfileAppendStock = new System.Windows.Forms.RadioButton();
       this.radioButtonOnlyOutfileNoStock = new System.Windows.Forms.RadioButton();
       this.radioButtonOutfileAppendStockAllAux = new System.Windows.Forms.RadioButton();
       this.radioButtonOutfileNoStockExcludeStockAux = new System.Windows.Forms.RadioButton();
       this.groupOutputViewer = new System.Windows.Forms.GroupBox();
-      this.radioButtonOutfileAppendStockExcludeStockAux = new System.Windows.Forms.RadioButton();
-      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
-      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
-      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.checkBoxEnableSummaryReport = new System.Windows.Forms.CheckBox();
       this.groupOuputOptions.SuspendLayout();
       ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).BeginInit();
       this.groupRefpoints.SuspendLayout();
       this.groupBounds.SuspendLayout();
       this.groupScaleFactors.SuspendLayout();
       this.groupRetroAdjustment.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.groupBox_StockSummmaryFlag.SuspendLayout();
       this.groupOutputViewer.SuspendLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.SuspendLayout();
       // 
       // groupOuputOptions
@@ -146,17 +146,6 @@
       this.checkBoxEnableAuxStochasticFiles.Text = "Generate Auxiliary Stochastic Data Files";
       this.checkBoxEnableAuxStochasticFiles.UseVisualStyleBackColor = true;
       // 
-      // checkBoxEnableSummaryReport
-      // 
-      this.checkBoxEnableSummaryReport.AutoSize = true;
-      this.checkBoxEnableSummaryReport.Location = new System.Drawing.Point(441, 489);
-      this.checkBoxEnableSummaryReport.Name = "checkBoxEnableSummaryReport";
-      this.checkBoxEnableSummaryReport.Size = new System.Drawing.Size(262, 17);
-      this.checkBoxEnableSummaryReport.TabIndex = 7;
-      this.checkBoxEnableSummaryReport.Text = "Output Summary Report of Stock Numbers At Age";
-      this.checkBoxEnableSummaryReport.UseVisualStyleBackColor = true;
-      this.checkBoxEnableSummaryReport.CheckedChanged += new System.EventHandler(this.CheckBoxEnableSummaryReport_CheckedChanged);
-      // 
       // groupRefpoints
       // 
       this.groupRefpoints.Controls.Add(this.textBoxRefFishMortality);
@@ -175,6 +164,16 @@
       this.groupRefpoints.TabStop = false;
       this.groupRefpoints.Text = "Reference Points";
       // 
+      // textBoxRefFishMortality
+      // 
+      this.textBoxRefFishMortality.Enabled = false;
+      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
+      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
+      this.textBoxRefFishMortality.ParamName = null;
+      this.textBoxRefFishMortality.PrevValidValue = "";
+      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefFishMortality.TabIndex = 8;
+      // 
       // labelFishMortality
       // 
       this.labelFishMortality.AutoSize = true;
@@ -184,6 +183,16 @@
       this.labelFishMortality.Size = new System.Drawing.Size(82, 13);
       this.labelFishMortality.TabIndex = 7;
       this.labelFishMortality.Text = "Fishing Mortality";
+      // 
+      // textBoxRefMeanBiomass
+      // 
+      this.textBoxRefMeanBiomass.Enabled = false;
+      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
+      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
+      this.textBoxRefMeanBiomass.ParamName = null;
+      this.textBoxRefMeanBiomass.PrevValidValue = "";
+      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefMeanBiomass.TabIndex = 6;
       // 
       // checkBoxEnableRefpoints
       // 
@@ -206,6 +215,16 @@
       this.labelMeanBiomass.TabIndex = 5;
       this.labelMeanBiomass.Text = "Mean Biomass (MT)";
       // 
+      // textBoxRefJan1Biomass
+      // 
+      this.textBoxRefJan1Biomass.Enabled = false;
+      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
+      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
+      this.textBoxRefJan1Biomass.ParamName = null;
+      this.textBoxRefJan1Biomass.PrevValidValue = "";
+      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefJan1Biomass.TabIndex = 4;
+      // 
       // labelJan1Biomass
       // 
       this.labelJan1Biomass.AutoSize = true;
@@ -215,6 +234,16 @@
       this.labelJan1Biomass.Size = new System.Drawing.Size(131, 13);
       this.labelJan1Biomass.TabIndex = 3;
       this.labelJan1Biomass.Text = "Jan-1 Stock Biomass (MT)";
+      // 
+      // textBoxRefSpawnBiomass
+      // 
+      this.textBoxRefSpawnBiomass.Enabled = false;
+      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
+      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
+      this.textBoxRefSpawnBiomass.ParamName = null;
+      this.textBoxRefSpawnBiomass.PrevValidValue = "";
+      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefSpawnBiomass.TabIndex = 2;
       // 
       // labelSpawnBiomass
       // 
@@ -240,6 +269,17 @@
       this.groupBounds.TabStop = false;
       this.groupBounds.Text = "Bounds";
       // 
+      // textBoxBoundsNatMortality
+      // 
+      this.textBoxBoundsNatMortality.Enabled = false;
+      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
+      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
+      this.textBoxBoundsNatMortality.ParamName = null;
+      this.textBoxBoundsNatMortality.PrevValidValue = "";
+      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsNatMortality.TabIndex = 4;
+      this.textBoxBoundsNatMortality.Text = "1.0";
+      // 
       // labelBoundsNatMortality
       // 
       this.labelBoundsNatMortality.AutoSize = true;
@@ -249,6 +289,17 @@
       this.labelBoundsNatMortality.Size = new System.Drawing.Size(130, 13);
       this.labelBoundsNatMortality.TabIndex = 3;
       this.labelBoundsNatMortality.Text = "Maximum Natural Mortality";
+      // 
+      // textBoxBoundsMaxWeight
+      // 
+      this.textBoxBoundsMaxWeight.Enabled = false;
+      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
+      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
+      this.textBoxBoundsMaxWeight.ParamName = null;
+      this.textBoxBoundsMaxWeight.PrevValidValue = "";
+      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsMaxWeight.TabIndex = 2;
+      this.textBoxBoundsMaxWeight.Text = "10.0";
       // 
       // labelBoundsMaxWeight
       // 
@@ -287,6 +338,16 @@
       this.groupScaleFactors.TabStop = false;
       this.groupScaleFactors.Text = "Scaling Factors for Output Report";
       // 
+      // textBoxScaleFactorRecruits
+      // 
+      this.textBoxScaleFactorRecruits.Enabled = false;
+      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(144, 74);
+      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
+      this.textBoxScaleFactorRecruits.ParamName = null;
+      this.textBoxScaleFactorRecruits.PrevValidValue = "";
+      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorRecruits.TabIndex = 4;
+      // 
       // labelScaleFactorRecruits
       // 
       this.labelScaleFactorRecruits.AutoSize = true;
@@ -297,6 +358,16 @@
       this.labelScaleFactorRecruits.TabIndex = 3;
       this.labelScaleFactorRecruits.Text = "Recruits";
       // 
+      // textBoxScaleFactorsStockNum
+      // 
+      this.textBoxScaleFactorsStockNum.Enabled = false;
+      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(144, 100);
+      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
+      this.textBoxScaleFactorsStockNum.ParamName = null;
+      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
+      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorsStockNum.TabIndex = 6;
+      // 
       // labelScaleFactorStockNum
       // 
       this.labelScaleFactorStockNum.AutoSize = true;
@@ -306,6 +377,16 @@
       this.labelScaleFactorStockNum.Size = new System.Drawing.Size(80, 13);
       this.labelScaleFactorStockNum.TabIndex = 5;
       this.labelScaleFactorStockNum.Text = "Stock Numbers";
+      // 
+      // textBoxScaleFactorBiomass
+      // 
+      this.textBoxScaleFactorBiomass.Enabled = false;
+      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(144, 48);
+      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
+      this.textBoxScaleFactorBiomass.ParamName = null;
+      this.textBoxScaleFactorBiomass.PrevValidValue = "";
+      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorBiomass.TabIndex = 2;
       // 
       // labelScaleFactorBiomass
       // 
@@ -350,6 +431,22 @@
       this.checkBoxEnableRetroAdjustment.UseVisualStyleBackColor = true;
       this.checkBoxEnableRetroAdjustment.CheckedChanged += new System.EventHandler(this.CheckBoxRetroAdjustment_CheckedChanged);
       // 
+      // dataGridRetroAdjustment
+      // 
+      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
+      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
+      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
+      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
+      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
+      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(17, 40);
+      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
+      this.dataGridRetroAdjustment.nftReadOnly = false;
+      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
+      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 171);
+      this.dataGridRetroAdjustment.TabIndex = 0;
+      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
+      // 
       // comboBoxOutputViewerProgram
       // 
       this.comboBoxOutputViewerProgram.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -384,6 +481,18 @@
       this.groupBox_StockSummmaryFlag.TabIndex = 0;
       this.groupBox_StockSummmaryFlag.TabStop = false;
       this.groupBox_StockSummmaryFlag.Text = "Stock Distribution Summary and Auxiliary Data Files";
+      // 
+      // radioButtonOutfileAppendStockExcludeStockAux
+      // 
+      this.radioButtonOutfileAppendStockExcludeStockAux.AutoSize = true;
+      this.radioButtonOutfileAppendStockExcludeStockAux.Location = new System.Drawing.Point(17, 109);
+      this.radioButtonOutfileAppendStockExcludeStockAux.Name = "radioButtonOutfileAppendStockExcludeStockAux";
+      this.radioButtonOutfileAppendStockExcludeStockAux.Size = new System.Drawing.Size(367, 17);
+      this.radioButtonOutfileAppendStockExcludeStockAux.TabIndex = 4;
+      this.radioButtonOutfileAppendStockExcludeStockAux.TabStop = true;
+      this.radioButtonOutfileAppendStockExcludeStockAux.Text = "Output File with Stock Distributions, Auxiliary Files EXCEPT Stock of Age";
+      this.radioButtonOutfileAppendStockExcludeStockAux.UseVisualStyleBackColor = true;
+      this.radioButtonOutfileAppendStockExcludeStockAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
       // 
       // radioButtonOnlyOutfileAppendStock
       // 
@@ -443,126 +552,7 @@
       this.groupOutputViewer.TabIndex = 3;
       this.groupOutputViewer.TabStop = false;
       this.groupOutputViewer.Text = "Output File Viewer";
-      // 
-      // radioButtonOutfileAppendStockExcludeStockAux
-      // 
-      this.radioButtonOutfileAppendStockExcludeStockAux.AutoSize = true;
-      this.radioButtonOutfileAppendStockExcludeStockAux.Location = new System.Drawing.Point(17, 109);
-      this.radioButtonOutfileAppendStockExcludeStockAux.Name = "radioButtonOutfileAppendStockExcludeStockAux";
-      this.radioButtonOutfileAppendStockExcludeStockAux.Size = new System.Drawing.Size(367, 17);
-      this.radioButtonOutfileAppendStockExcludeStockAux.TabIndex = 4;
-      this.radioButtonOutfileAppendStockExcludeStockAux.TabStop = true;
-      this.radioButtonOutfileAppendStockExcludeStockAux.Text = "Output File with Stock Distributions, Auxiliary Files EXCEPT Stock of Age";
-      this.radioButtonOutfileAppendStockExcludeStockAux.UseVisualStyleBackColor = true;
-      this.radioButtonOutfileAppendStockExcludeStockAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
-      // 
-      // dataGridRetroAdjustment
-      // 
-      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
-      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
-      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
-      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
-      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
-      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(17, 40);
-      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
-      this.dataGridRetroAdjustment.nftReadOnly = false;
-      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
-      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 171);
-      this.dataGridRetroAdjustment.TabIndex = 0;
-      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
-      // 
-      // textBoxScaleFactorRecruits
-      // 
-      this.textBoxScaleFactorRecruits.Enabled = false;
-      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(144, 74);
-      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
-      this.textBoxScaleFactorRecruits.ParamName = null;
-      this.textBoxScaleFactorRecruits.PrevValidValue = "";
-      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorRecruits.TabIndex = 4;
-      // 
-      // textBoxScaleFactorsStockNum
-      // 
-      this.textBoxScaleFactorsStockNum.Enabled = false;
-      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(144, 100);
-      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
-      this.textBoxScaleFactorsStockNum.ParamName = null;
-      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
-      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorsStockNum.TabIndex = 6;
-      // 
-      // textBoxScaleFactorBiomass
-      // 
-      this.textBoxScaleFactorBiomass.Enabled = false;
-      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(144, 48);
-      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
-      this.textBoxScaleFactorBiomass.ParamName = null;
-      this.textBoxScaleFactorBiomass.PrevValidValue = "";
-      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorBiomass.TabIndex = 2;
-      // 
-      // textBoxBoundsNatMortality
-      // 
-      this.textBoxBoundsNatMortality.Enabled = false;
-      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
-      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
-      this.textBoxBoundsNatMortality.ParamName = null;
-      this.textBoxBoundsNatMortality.PrevValidValue = "";
-      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
-      this.textBoxBoundsNatMortality.TabIndex = 4;
-      this.textBoxBoundsNatMortality.Text = "1.0";
-      // 
-      // textBoxBoundsMaxWeight
-      // 
-      this.textBoxBoundsMaxWeight.Enabled = false;
-      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
-      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
-      this.textBoxBoundsMaxWeight.ParamName = null;
-      this.textBoxBoundsMaxWeight.PrevValidValue = "";
-      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
-      this.textBoxBoundsMaxWeight.TabIndex = 2;
-      this.textBoxBoundsMaxWeight.Text = "10.0";
-      // 
-      // textBoxRefFishMortality
-      // 
-      this.textBoxRefFishMortality.Enabled = false;
-      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
-      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
-      this.textBoxRefFishMortality.ParamName = null;
-      this.textBoxRefFishMortality.PrevValidValue = "";
-      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefFishMortality.TabIndex = 8;
-      // 
-      // textBoxRefMeanBiomass
-      // 
-      this.textBoxRefMeanBiomass.Enabled = false;
-      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
-      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
-      this.textBoxRefMeanBiomass.ParamName = null;
-      this.textBoxRefMeanBiomass.PrevValidValue = "";
-      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefMeanBiomass.TabIndex = 6;
-      // 
-      // textBoxRefJan1Biomass
-      // 
-      this.textBoxRefJan1Biomass.Enabled = false;
-      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
-      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
-      this.textBoxRefJan1Biomass.ParamName = null;
-      this.textBoxRefJan1Biomass.PrevValidValue = "";
-      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefJan1Biomass.TabIndex = 4;
-      // 
-      // textBoxRefSpawnBiomass
-      // 
-      this.textBoxRefSpawnBiomass.Enabled = false;
-      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
-      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
-      this.textBoxRefSpawnBiomass.ParamName = null;
-      this.textBoxRefSpawnBiomass.PrevValidValue = "";
-      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefSpawnBiomass.TabIndex = 2;
+
       // 
       // ControlMiscOptions
       // 
@@ -589,11 +579,11 @@
       this.groupScaleFactors.PerformLayout();
       this.groupRetroAdjustment.ResumeLayout(false);
       this.groupRetroAdjustment.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.groupBox_StockSummmaryFlag.ResumeLayout(false);
       this.groupBox_StockSummmaryFlag.PerformLayout();
       this.groupOutputViewer.ResumeLayout(false);
       this.groupOutputViewer.PerformLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.ResumeLayout(false);
       this.PerformLayout();
 
@@ -606,7 +596,6 @@
         private System.Windows.Forms.CheckBox checkBoxEnablePercentileReport;
         private System.Windows.Forms.CheckBox checkBoxEnableExportR;
         private System.Windows.Forms.CheckBox checkBoxEnableAuxStochasticFiles;
-        private System.Windows.Forms.CheckBox checkBoxEnableSummaryReport;
         private System.Windows.Forms.GroupBox groupRefpoints;
         private Nmfs.Agepro.Gui.NftTextBox textBoxRefFishMortality;
         private System.Windows.Forms.Label labelFishMortality;
@@ -644,5 +633,6 @@
     private System.Windows.Forms.RadioButton radioButtonOnlyOutfileAppendStock;
     private System.Windows.Forms.GroupBox groupOutputViewer;
     private System.Windows.Forms.RadioButton radioButtonOutfileAppendStockExcludeStockAux;
+    private System.Windows.Forms.CheckBox checkBoxEnableSummaryReport;
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -28,470 +28,488 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.groupOuputOptions = new System.Windows.Forms.GroupBox();
-            this.spinBoxReportPercentile = new System.Windows.Forms.NumericUpDown();
-            this.labelReportPercentile = new System.Windows.Forms.Label();
-            this.checkBoxEnablePercentileReport = new System.Windows.Forms.CheckBox();
-            this.checkBoxEnableExportR = new System.Windows.Forms.CheckBox();
-            this.checkBoxEnableAuxStochasticFiles = new System.Windows.Forms.CheckBox();
-            this.checkBoxEnableSummaryReport = new System.Windows.Forms.CheckBox();
-            this.groupRefpoints = new System.Windows.Forms.GroupBox();
-            this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
-            this.labelFishMortality = new System.Windows.Forms.Label();
-            this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
-            this.checkBoxEnableRefpoints = new System.Windows.Forms.CheckBox();
-            this.labelMeanBiomass = new System.Windows.Forms.Label();
-            this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
-            this.labelJan1Biomass = new System.Windows.Forms.Label();
-            this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
-            this.labelSpawnBiomass = new System.Windows.Forms.Label();
-            this.groupBounds = new System.Windows.Forms.GroupBox();
-            this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
-            this.labelBoundsNatMortality = new System.Windows.Forms.Label();
-            this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
-            this.labelBoundsMaxWeight = new System.Windows.Forms.Label();
-            this.checkBoxBounds = new System.Windows.Forms.CheckBox();
-            this.groupScaleFactors = new System.Windows.Forms.GroupBox();
-            this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
-            this.labelScaleFactorRecruits = new System.Windows.Forms.Label();
-            this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
-            this.labelScaleFactorStockNum = new System.Windows.Forms.Label();
-            this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
-            this.labelScaleFactorBiomass = new System.Windows.Forms.Label();
-            this.checkBoxEnableScaleFactors = new System.Windows.Forms.CheckBox();
-            this.groupRetroAdjustment = new System.Windows.Forms.GroupBox();
-            this.checkBoxEnableRetroAdjustment = new System.Windows.Forms.CheckBox();
-            this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
-            this.groupOutputViewer = new System.Windows.Forms.GroupBox();
-            this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
-            this.labelOutputViewerProgram = new System.Windows.Forms.Label();
-            this.groupOuputOptions.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).BeginInit();
-            this.groupRefpoints.SuspendLayout();
-            this.groupBounds.SuspendLayout();
-            this.groupScaleFactors.SuspendLayout();
-            this.groupRetroAdjustment.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
-            this.groupOutputViewer.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // groupOuputOptions
-            // 
-            this.groupOuputOptions.Controls.Add(this.spinBoxReportPercentile);
-            this.groupOuputOptions.Controls.Add(this.labelReportPercentile);
-            this.groupOuputOptions.Controls.Add(this.checkBoxEnablePercentileReport);
-            this.groupOuputOptions.Controls.Add(this.checkBoxEnableExportR);
-            this.groupOuputOptions.Controls.Add(this.checkBoxEnableAuxStochasticFiles);
-            this.groupOuputOptions.Controls.Add(this.checkBoxEnableSummaryReport);
-            this.groupOuputOptions.Location = new System.Drawing.Point(29, 15);
-            this.groupOuputOptions.Name = "groupOuputOptions";
-            this.groupOuputOptions.Size = new System.Drawing.Size(353, 143);
-            this.groupOuputOptions.TabIndex = 0;
-            this.groupOuputOptions.TabStop = false;
-            this.groupOuputOptions.Text = "Output Options";
-            // 
-            // spinBoxReportPercentile
-            // 
-            this.spinBoxReportPercentile.DecimalPlaces = 1;
-            this.spinBoxReportPercentile.Enabled = false;
-            this.spinBoxReportPercentile.Location = new System.Drawing.Point(165, 114);
-            this.spinBoxReportPercentile.Name = "spinBoxReportPercentile";
-            this.spinBoxReportPercentile.Size = new System.Drawing.Size(107, 20);
-            this.spinBoxReportPercentile.TabIndex = 5;
-            // 
-            // labelReportPercentile
-            // 
-            this.labelReportPercentile.AutoSize = true;
-            this.labelReportPercentile.Enabled = false;
-            this.labelReportPercentile.Location = new System.Drawing.Point(70, 116);
-            this.labelReportPercentile.Name = "labelReportPercentile";
-            this.labelReportPercentile.Size = new System.Drawing.Size(89, 13);
-            this.labelReportPercentile.TabIndex = 4;
-            this.labelReportPercentile.Text = "Report Percentile";
-            // 
-            // checkBoxEnablePercentileReport
-            // 
-            this.checkBoxEnablePercentileReport.AutoSize = true;
-            this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(23, 92);
-            this.checkBoxEnablePercentileReport.Name = "checkBoxEnablePercentileReport";
-            this.checkBoxEnablePercentileReport.Size = new System.Drawing.Size(151, 17);
-            this.checkBoxEnablePercentileReport.TabIndex = 3;
-            this.checkBoxEnablePercentileReport.Text = "Request Percentile Report";
-            this.checkBoxEnablePercentileReport.UseVisualStyleBackColor = true;
-            this.checkBoxEnablePercentileReport.CheckedChanged += new System.EventHandler(this.CheckBoxPercentileReport_CheckedChanged);
-            // 
-            // checkBoxEnableExportR
-            // 
-            this.checkBoxEnableExportR.AutoSize = true;
-            this.checkBoxEnableExportR.Location = new System.Drawing.Point(23, 69);
-            this.checkBoxEnableExportR.Name = "checkBoxEnableExportR";
-            this.checkBoxEnableExportR.Size = new System.Drawing.Size(117, 17);
-            this.checkBoxEnableExportR.TabIndex = 2;
-            this.checkBoxEnableExportR.Text = "Export Results to R";
-            this.checkBoxEnableExportR.UseVisualStyleBackColor = true;
-            // 
-            // checkBoxEnableAuxStochasticFiles
-            // 
-            this.checkBoxEnableAuxStochasticFiles.AutoSize = true;
-            this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(23, 46);
-            this.checkBoxEnableAuxStochasticFiles.Name = "checkBoxEnableAuxStochasticFiles";
-            this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(214, 17);
-            this.checkBoxEnableAuxStochasticFiles.TabIndex = 1;
-            this.checkBoxEnableAuxStochasticFiles.Text = "Generate Auxiliary Stochastic Data Files";
-            this.checkBoxEnableAuxStochasticFiles.UseVisualStyleBackColor = true;
-            // 
-            // checkBoxEnableSummaryReport
-            // 
-            this.checkBoxEnableSummaryReport.AutoSize = true;
-            this.checkBoxEnableSummaryReport.Location = new System.Drawing.Point(23, 23);
-            this.checkBoxEnableSummaryReport.Name = "checkBoxEnableSummaryReport";
-            this.checkBoxEnableSummaryReport.Size = new System.Drawing.Size(262, 17);
-            this.checkBoxEnableSummaryReport.TabIndex = 0;
-            this.checkBoxEnableSummaryReport.Text = "Output Summary Report of Stock Numbers At Age";
-            this.checkBoxEnableSummaryReport.UseVisualStyleBackColor = true;
-            // 
-            // groupRefpoints
-            // 
-            this.groupRefpoints.Controls.Add(this.textBoxRefFishMortality);
-            this.groupRefpoints.Controls.Add(this.labelFishMortality);
-            this.groupRefpoints.Controls.Add(this.textBoxRefMeanBiomass);
-            this.groupRefpoints.Controls.Add(this.checkBoxEnableRefpoints);
-            this.groupRefpoints.Controls.Add(this.labelMeanBiomass);
-            this.groupRefpoints.Controls.Add(this.textBoxRefJan1Biomass);
-            this.groupRefpoints.Controls.Add(this.labelJan1Biomass);
-            this.groupRefpoints.Controls.Add(this.textBoxRefSpawnBiomass);
-            this.groupRefpoints.Controls.Add(this.labelSpawnBiomass);
-            this.groupRefpoints.Location = new System.Drawing.Point(29, 164);
-            this.groupRefpoints.Name = "groupRefpoints";
-            this.groupRefpoints.Size = new System.Drawing.Size(353, 152);
-            this.groupRefpoints.TabIndex = 1;
-            this.groupRefpoints.TabStop = false;
-            this.groupRefpoints.Text = "Reference Points";
-            // 
-            // textBoxRefFishMortality
-            // 
-            this.textBoxRefFishMortality.Enabled = false;
-            this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
-            this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
-            this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
-            this.textBoxRefFishMortality.TabIndex = 8;
-            // 
-            // labelFishMortality
-            // 
-            this.labelFishMortality.AutoSize = true;
-            this.labelFishMortality.Enabled = false;
-            this.labelFishMortality.Location = new System.Drawing.Point(19, 123);
-            this.labelFishMortality.Name = "labelFishMortality";
-            this.labelFishMortality.Size = new System.Drawing.Size(82, 13);
-            this.labelFishMortality.TabIndex = 7;
-            this.labelFishMortality.Text = "Fishing Mortality";
-            // 
-            // textBoxRefMeanBiomass
-            // 
-            this.textBoxRefMeanBiomass.Enabled = false;
-            this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
-            this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
-            this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
-            this.textBoxRefMeanBiomass.TabIndex = 6;
-            // 
-            // checkBoxEnableRefpoints
-            // 
-            this.checkBoxEnableRefpoints.AutoSize = true;
-            this.checkBoxEnableRefpoints.Location = new System.Drawing.Point(22, 19);
-            this.checkBoxEnableRefpoints.Name = "checkBoxEnableRefpoints";
-            this.checkBoxEnableRefpoints.Size = new System.Drawing.Size(224, 17);
-            this.checkBoxEnableRefpoints.TabIndex = 0;
-            this.checkBoxEnableRefpoints.Text = "Enable Reference Point Threshold Report";
-            this.checkBoxEnableRefpoints.UseVisualStyleBackColor = true;
-            this.checkBoxEnableRefpoints.CheckedChanged += new System.EventHandler(this.CheckBoxRefpoints_CheckedChanged);
-            // 
-            // labelMeanBiomass
-            // 
-            this.labelMeanBiomass.AutoSize = true;
-            this.labelMeanBiomass.Enabled = false;
-            this.labelMeanBiomass.Location = new System.Drawing.Point(19, 97);
-            this.labelMeanBiomass.Name = "labelMeanBiomass";
-            this.labelMeanBiomass.Size = new System.Drawing.Size(101, 13);
-            this.labelMeanBiomass.TabIndex = 5;
-            this.labelMeanBiomass.Text = "Mean Biomass (MT)";
-            // 
-            // textBoxRefJan1Biomass
-            // 
-            this.textBoxRefJan1Biomass.Enabled = false;
-            this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
-            this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
-            this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
-            this.textBoxRefJan1Biomass.TabIndex = 4;
-            // 
-            // labelJan1Biomass
-            // 
-            this.labelJan1Biomass.AutoSize = true;
-            this.labelJan1Biomass.Enabled = false;
-            this.labelJan1Biomass.Location = new System.Drawing.Point(19, 71);
-            this.labelJan1Biomass.Name = "labelJan1Biomass";
-            this.labelJan1Biomass.Size = new System.Drawing.Size(131, 13);
-            this.labelJan1Biomass.TabIndex = 3;
-            this.labelJan1Biomass.Text = "Jan-1 Stock Biomass (MT)";
-            // 
-            // textBoxRefSpawnBiomass
-            // 
-            this.textBoxRefSpawnBiomass.Enabled = false;
-            this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
-            this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
-            this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
-            this.textBoxRefSpawnBiomass.TabIndex = 2;
-            // 
-            // labelSpawnBiomass
-            // 
-            this.labelSpawnBiomass.AutoSize = true;
-            this.labelSpawnBiomass.Enabled = false;
-            this.labelSpawnBiomass.Location = new System.Drawing.Point(19, 45);
-            this.labelSpawnBiomass.Name = "labelSpawnBiomass";
-            this.labelSpawnBiomass.Size = new System.Drawing.Size(152, 13);
-            this.labelSpawnBiomass.TabIndex = 1;
-            this.labelSpawnBiomass.Text = "Spawning Stock Biomass (MT)";
-            // 
-            // groupBounds
-            // 
-            this.groupBounds.Controls.Add(this.textBoxBoundsNatMortality);
-            this.groupBounds.Controls.Add(this.labelBoundsNatMortality);
-            this.groupBounds.Controls.Add(this.textBoxBoundsMaxWeight);
-            this.groupBounds.Controls.Add(this.labelBoundsMaxWeight);
-            this.groupBounds.Controls.Add(this.checkBoxBounds);
-            this.groupBounds.Location = new System.Drawing.Point(402, 15);
-            this.groupBounds.Name = "groupBounds";
-            this.groupBounds.Size = new System.Drawing.Size(353, 99);
-            this.groupBounds.TabIndex = 3;
-            this.groupBounds.TabStop = false;
-            this.groupBounds.Text = "Bounds";
-            // 
-            // textBoxBoundsNatMortality
-            // 
-            this.textBoxBoundsNatMortality.Enabled = false;
-            this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
-            this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
-            this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
-            this.textBoxBoundsNatMortality.TabIndex = 4;
-            this.textBoxBoundsNatMortality.Text = "1.0";
-            // 
-            // labelBoundsNatMortality
-            // 
-            this.labelBoundsNatMortality.AutoSize = true;
-            this.labelBoundsNatMortality.Enabled = false;
-            this.labelBoundsNatMortality.Location = new System.Drawing.Point(15, 71);
-            this.labelBoundsNatMortality.Name = "labelBoundsNatMortality";
-            this.labelBoundsNatMortality.Size = new System.Drawing.Size(130, 13);
-            this.labelBoundsNatMortality.TabIndex = 3;
-            this.labelBoundsNatMortality.Text = "Maximum Natural Mortality";
-            // 
-            // textBoxBoundsMaxWeight
-            // 
-            this.textBoxBoundsMaxWeight.Enabled = false;
-            this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
-            this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
-            this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
-            this.textBoxBoundsMaxWeight.TabIndex = 2;
-            this.textBoxBoundsMaxWeight.Text = "10.0";
-            // 
-            // labelBoundsMaxWeight
-            // 
-            this.labelBoundsMaxWeight.AutoSize = true;
-            this.labelBoundsMaxWeight.Enabled = false;
-            this.labelBoundsMaxWeight.Location = new System.Drawing.Point(15, 45);
-            this.labelBoundsMaxWeight.Name = "labelBoundsMaxWeight";
-            this.labelBoundsMaxWeight.Size = new System.Drawing.Size(109, 13);
-            this.labelBoundsMaxWeight.TabIndex = 1;
-            this.labelBoundsMaxWeight.Text = "Maximum Weight (kg)";
-            // 
-            // checkBoxBounds
-            // 
-            this.checkBoxBounds.AutoSize = true;
-            this.checkBoxBounds.Location = new System.Drawing.Point(18, 19);
-            this.checkBoxBounds.Name = "checkBoxBounds";
-            this.checkBoxBounds.Size = new System.Drawing.Size(100, 17);
-            this.checkBoxBounds.TabIndex = 0;
-            this.checkBoxBounds.Text = "Specify Bounds";
-            this.checkBoxBounds.UseVisualStyleBackColor = true;
-            this.checkBoxBounds.CheckedChanged += new System.EventHandler(this.CheckBoxBounds_CheckedChanged);
-            // 
-            // groupScaleFactors
-            // 
-            this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorRecruits);
-            this.groupScaleFactors.Controls.Add(this.labelScaleFactorRecruits);
-            this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorsStockNum);
-            this.groupScaleFactors.Controls.Add(this.labelScaleFactorStockNum);
-            this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorBiomass);
-            this.groupScaleFactors.Controls.Add(this.labelScaleFactorBiomass);
-            this.groupScaleFactors.Controls.Add(this.checkBoxEnableScaleFactors);
-            this.groupScaleFactors.Location = new System.Drawing.Point(29, 322);
-            this.groupScaleFactors.Name = "groupScaleFactors";
-            this.groupScaleFactors.Size = new System.Drawing.Size(353, 136);
-            this.groupScaleFactors.TabIndex = 2;
-            this.groupScaleFactors.TabStop = false;
-            this.groupScaleFactors.Text = "Scaling Factors for Output Report";
-            // 
-            // textBoxScaleFactorRecruits
-            // 
-            this.textBoxScaleFactorRecruits.Enabled = false;
-            this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(144, 74);
-            this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
-            this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
-            this.textBoxScaleFactorRecruits.TabIndex = 4;
-            // 
-            // labelScaleFactorRecruits
-            // 
-            this.labelScaleFactorRecruits.AutoSize = true;
-            this.labelScaleFactorRecruits.Enabled = false;
-            this.labelScaleFactorRecruits.Location = new System.Drawing.Point(20, 77);
-            this.labelScaleFactorRecruits.Name = "labelScaleFactorRecruits";
-            this.labelScaleFactorRecruits.Size = new System.Drawing.Size(46, 13);
-            this.labelScaleFactorRecruits.TabIndex = 3;
-            this.labelScaleFactorRecruits.Text = "Recruits";
-            // 
-            // textBoxScaleFactorsStockNum
-            // 
-            this.textBoxScaleFactorsStockNum.Enabled = false;
-            this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(144, 100);
-            this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
-            this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
-            this.textBoxScaleFactorsStockNum.TabIndex = 6;
-            // 
-            // labelScaleFactorStockNum
-            // 
-            this.labelScaleFactorStockNum.AutoSize = true;
-            this.labelScaleFactorStockNum.Enabled = false;
-            this.labelScaleFactorStockNum.Location = new System.Drawing.Point(19, 103);
-            this.labelScaleFactorStockNum.Name = "labelScaleFactorStockNum";
-            this.labelScaleFactorStockNum.Size = new System.Drawing.Size(80, 13);
-            this.labelScaleFactorStockNum.TabIndex = 5;
-            this.labelScaleFactorStockNum.Text = "Stock Numbers";
-            // 
-            // textBoxScaleFactorBiomass
-            // 
-            this.textBoxScaleFactorBiomass.Enabled = false;
-            this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(144, 48);
-            this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
-            this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
-            this.textBoxScaleFactorBiomass.TabIndex = 2;
-            // 
-            // labelScaleFactorBiomass
-            // 
-            this.labelScaleFactorBiomass.AutoSize = true;
-            this.labelScaleFactorBiomass.Enabled = false;
-            this.labelScaleFactorBiomass.Location = new System.Drawing.Point(20, 51);
-            this.labelScaleFactorBiomass.Name = "labelScaleFactorBiomass";
-            this.labelScaleFactorBiomass.Size = new System.Drawing.Size(46, 13);
-            this.labelScaleFactorBiomass.TabIndex = 1;
-            this.labelScaleFactorBiomass.Text = "Biomass";
-            // 
-            // checkBoxEnableScaleFactors
-            // 
-            this.checkBoxEnableScaleFactors.AutoSize = true;
-            this.checkBoxEnableScaleFactors.Location = new System.Drawing.Point(22, 20);
-            this.checkBoxEnableScaleFactors.Name = "checkBoxEnableScaleFactors";
-            this.checkBoxEnableScaleFactors.Size = new System.Drawing.Size(233, 17);
-            this.checkBoxEnableScaleFactors.TabIndex = 0;
-            this.checkBoxEnableScaleFactors.Text = "Specify Scale Factors for Output Report File";
-            this.checkBoxEnableScaleFactors.UseVisualStyleBackColor = true;
-            this.checkBoxEnableScaleFactors.CheckedChanged += new System.EventHandler(this.CheckBoxScaleFactors_CheckedChanged);
-            // 
-            // groupRetroAdjustment
-            // 
-            this.groupRetroAdjustment.Controls.Add(this.checkBoxEnableRetroAdjustment);
-            this.groupRetroAdjustment.Controls.Add(this.dataGridRetroAdjustment);
-            this.groupRetroAdjustment.Location = new System.Drawing.Point(403, 120);
-            this.groupRetroAdjustment.Name = "groupRetroAdjustment";
-            this.groupRetroAdjustment.Size = new System.Drawing.Size(352, 266);
-            this.groupRetroAdjustment.TabIndex = 4;
-            this.groupRetroAdjustment.TabStop = false;
-            this.groupRetroAdjustment.Text = "Retrospective Adjustment Factors";
-            // 
-            // checkBoxEnableRetroAdjustment
-            // 
-            this.checkBoxEnableRetroAdjustment.AutoSize = true;
-            this.checkBoxEnableRetroAdjustment.Location = new System.Drawing.Point(17, 20);
-            this.checkBoxEnableRetroAdjustment.Name = "checkBoxEnableRetroAdjustment";
-            this.checkBoxEnableRetroAdjustment.Size = new System.Drawing.Size(223, 17);
-            this.checkBoxEnableRetroAdjustment.TabIndex = 1;
-            this.checkBoxEnableRetroAdjustment.Text = "Specify Retrospective Adjustment Factors";
-            this.checkBoxEnableRetroAdjustment.UseVisualStyleBackColor = true;
-            this.checkBoxEnableRetroAdjustment.CheckedChanged += new System.EventHandler(this.CheckBoxRetroAdjustment_CheckedChanged);
-            // 
-            // dataGridRetroAdjustment
-            // 
-            this.dataGridRetroAdjustment.AllowUserToAddRows = false;
-            this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
-            this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
-            this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
-            this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
-            this.dataGridRetroAdjustment.Location = new System.Drawing.Point(17, 40);
-            this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
-            this.dataGridRetroAdjustment.nftReadOnly = false;
-            this.dataGridRetroAdjustment.RowHeadersWidth = 75;
-            this.dataGridRetroAdjustment.Size = new System.Drawing.Size(329, 220);
-            this.dataGridRetroAdjustment.TabIndex = 0;
-            this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
-            // 
-            // groupOutputViewer
-            // 
-            this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
-            this.groupOutputViewer.Controls.Add(this.labelOutputViewerProgram);
-            this.groupOutputViewer.Location = new System.Drawing.Point(403, 392);
-            this.groupOutputViewer.Name = "groupOutputViewer";
-            this.groupOutputViewer.Size = new System.Drawing.Size(352, 75);
-            this.groupOutputViewer.TabIndex = 5;
-            this.groupOutputViewer.TabStop = false;
-            this.groupOutputViewer.Text = "Output File Viewer";
-            // 
-            // comboBoxOutputViewerProgram
-            // 
-            this.comboBoxOutputViewerProgram.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.comboBoxOutputViewerProgram.Items.AddRange(new object[] {
+      this.groupOuputOptions = new System.Windows.Forms.GroupBox();
+      this.spinBoxReportPercentile = new System.Windows.Forms.NumericUpDown();
+      this.labelReportPercentile = new System.Windows.Forms.Label();
+      this.checkBoxEnablePercentileReport = new System.Windows.Forms.CheckBox();
+      this.checkBoxEnableExportR = new System.Windows.Forms.CheckBox();
+      this.checkBoxEnableAuxStochasticFiles = new System.Windows.Forms.CheckBox();
+      this.checkBoxEnableSummaryReport = new System.Windows.Forms.CheckBox();
+      this.groupRefpoints = new System.Windows.Forms.GroupBox();
+      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelFishMortality = new System.Windows.Forms.Label();
+      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.checkBoxEnableRefpoints = new System.Windows.Forms.CheckBox();
+      this.labelMeanBiomass = new System.Windows.Forms.Label();
+      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelJan1Biomass = new System.Windows.Forms.Label();
+      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelSpawnBiomass = new System.Windows.Forms.Label();
+      this.groupBounds = new System.Windows.Forms.GroupBox();
+      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelBoundsNatMortality = new System.Windows.Forms.Label();
+      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelBoundsMaxWeight = new System.Windows.Forms.Label();
+      this.checkBoxBounds = new System.Windows.Forms.CheckBox();
+      this.groupScaleFactors = new System.Windows.Forms.GroupBox();
+      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelScaleFactorRecruits = new System.Windows.Forms.Label();
+      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelScaleFactorStockNum = new System.Windows.Forms.Label();
+      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.labelScaleFactorBiomass = new System.Windows.Forms.Label();
+      this.checkBoxEnableScaleFactors = new System.Windows.Forms.CheckBox();
+      this.groupRetroAdjustment = new System.Windows.Forms.GroupBox();
+      this.checkBoxEnableRetroAdjustment = new System.Windows.Forms.CheckBox();
+      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
+      this.groupOutputViewer = new System.Windows.Forms.GroupBox();
+      this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
+      this.labelOutputViewerProgram = new System.Windows.Forms.Label();
+      this.groupOuputOptions.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).BeginInit();
+      this.groupRefpoints.SuspendLayout();
+      this.groupBounds.SuspendLayout();
+      this.groupScaleFactors.SuspendLayout();
+      this.groupRetroAdjustment.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
+      this.groupOutputViewer.SuspendLayout();
+      this.SuspendLayout();
+      // 
+      // groupOuputOptions
+      // 
+      this.groupOuputOptions.Controls.Add(this.spinBoxReportPercentile);
+      this.groupOuputOptions.Controls.Add(this.labelReportPercentile);
+      this.groupOuputOptions.Controls.Add(this.checkBoxEnablePercentileReport);
+      this.groupOuputOptions.Controls.Add(this.checkBoxEnableExportR);
+      this.groupOuputOptions.Controls.Add(this.checkBoxEnableAuxStochasticFiles);
+      this.groupOuputOptions.Controls.Add(this.checkBoxEnableSummaryReport);
+      this.groupOuputOptions.Location = new System.Drawing.Point(29, 15);
+      this.groupOuputOptions.Name = "groupOuputOptions";
+      this.groupOuputOptions.Size = new System.Drawing.Size(353, 171);
+      this.groupOuputOptions.TabIndex = 0;
+      this.groupOuputOptions.TabStop = false;
+      this.groupOuputOptions.Text = "Output Options";
+      // 
+      // spinBoxReportPercentile
+      // 
+      this.spinBoxReportPercentile.DecimalPlaces = 1;
+      this.spinBoxReportPercentile.Enabled = false;
+      this.spinBoxReportPercentile.Location = new System.Drawing.Point(165, 114);
+      this.spinBoxReportPercentile.Name = "spinBoxReportPercentile";
+      this.spinBoxReportPercentile.Size = new System.Drawing.Size(107, 20);
+      this.spinBoxReportPercentile.TabIndex = 5;
+      // 
+      // labelReportPercentile
+      // 
+      this.labelReportPercentile.AutoSize = true;
+      this.labelReportPercentile.Enabled = false;
+      this.labelReportPercentile.Location = new System.Drawing.Point(70, 116);
+      this.labelReportPercentile.Name = "labelReportPercentile";
+      this.labelReportPercentile.Size = new System.Drawing.Size(89, 13);
+      this.labelReportPercentile.TabIndex = 4;
+      this.labelReportPercentile.Text = "Report Percentile";
+      // 
+      // checkBoxEnablePercentileReport
+      // 
+      this.checkBoxEnablePercentileReport.AutoSize = true;
+      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(23, 92);
+      this.checkBoxEnablePercentileReport.Name = "checkBoxEnablePercentileReport";
+      this.checkBoxEnablePercentileReport.Size = new System.Drawing.Size(151, 17);
+      this.checkBoxEnablePercentileReport.TabIndex = 3;
+      this.checkBoxEnablePercentileReport.Text = "Request Percentile Report";
+      this.checkBoxEnablePercentileReport.UseVisualStyleBackColor = true;
+      this.checkBoxEnablePercentileReport.CheckedChanged += new System.EventHandler(this.CheckBoxPercentileReport_CheckedChanged);
+      // 
+      // checkBoxEnableExportR
+      // 
+      this.checkBoxEnableExportR.AutoSize = true;
+      this.checkBoxEnableExportR.Location = new System.Drawing.Point(23, 69);
+      this.checkBoxEnableExportR.Name = "checkBoxEnableExportR";
+      this.checkBoxEnableExportR.Size = new System.Drawing.Size(117, 17);
+      this.checkBoxEnableExportR.TabIndex = 2;
+      this.checkBoxEnableExportR.Text = "Export Results to R";
+      this.checkBoxEnableExportR.UseVisualStyleBackColor = true;
+      // 
+      // checkBoxEnableAuxStochasticFiles
+      // 
+      this.checkBoxEnableAuxStochasticFiles.AutoSize = true;
+      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(23, 46);
+      this.checkBoxEnableAuxStochasticFiles.Name = "checkBoxEnableAuxStochasticFiles";
+      this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(214, 17);
+      this.checkBoxEnableAuxStochasticFiles.TabIndex = 1;
+      this.checkBoxEnableAuxStochasticFiles.Text = "Generate Auxiliary Stochastic Data Files";
+      this.checkBoxEnableAuxStochasticFiles.UseVisualStyleBackColor = true;
+      // 
+      // checkBoxEnableSummaryReport
+      // 
+      this.checkBoxEnableSummaryReport.AutoSize = true;
+      this.checkBoxEnableSummaryReport.Location = new System.Drawing.Point(23, 23);
+      this.checkBoxEnableSummaryReport.Name = "checkBoxEnableSummaryReport";
+      this.checkBoxEnableSummaryReport.Size = new System.Drawing.Size(262, 17);
+      this.checkBoxEnableSummaryReport.TabIndex = 0;
+      this.checkBoxEnableSummaryReport.Text = "Output Summary Report of Stock Numbers At Age";
+      this.checkBoxEnableSummaryReport.UseVisualStyleBackColor = true;
+      // 
+      // groupRefpoints
+      // 
+      this.groupRefpoints.Controls.Add(this.textBoxRefFishMortality);
+      this.groupRefpoints.Controls.Add(this.labelFishMortality);
+      this.groupRefpoints.Controls.Add(this.textBoxRefMeanBiomass);
+      this.groupRefpoints.Controls.Add(this.checkBoxEnableRefpoints);
+      this.groupRefpoints.Controls.Add(this.labelMeanBiomass);
+      this.groupRefpoints.Controls.Add(this.textBoxRefJan1Biomass);
+      this.groupRefpoints.Controls.Add(this.labelJan1Biomass);
+      this.groupRefpoints.Controls.Add(this.textBoxRefSpawnBiomass);
+      this.groupRefpoints.Controls.Add(this.labelSpawnBiomass);
+      this.groupRefpoints.Location = new System.Drawing.Point(29, 192);
+      this.groupRefpoints.Name = "groupRefpoints";
+      this.groupRefpoints.Size = new System.Drawing.Size(353, 152);
+      this.groupRefpoints.TabIndex = 1;
+      this.groupRefpoints.TabStop = false;
+      this.groupRefpoints.Text = "Reference Points";
+      // 
+      // textBoxRefFishMortality
+      // 
+      this.textBoxRefFishMortality.Enabled = false;
+      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
+      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
+      this.textBoxRefFishMortality.ParamName = null;
+      this.textBoxRefFishMortality.PrevValidValue = "";
+      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefFishMortality.TabIndex = 8;
+      // 
+      // labelFishMortality
+      // 
+      this.labelFishMortality.AutoSize = true;
+      this.labelFishMortality.Enabled = false;
+      this.labelFishMortality.Location = new System.Drawing.Point(19, 123);
+      this.labelFishMortality.Name = "labelFishMortality";
+      this.labelFishMortality.Size = new System.Drawing.Size(82, 13);
+      this.labelFishMortality.TabIndex = 7;
+      this.labelFishMortality.Text = "Fishing Mortality";
+      // 
+      // textBoxRefMeanBiomass
+      // 
+      this.textBoxRefMeanBiomass.Enabled = false;
+      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
+      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
+      this.textBoxRefMeanBiomass.ParamName = null;
+      this.textBoxRefMeanBiomass.PrevValidValue = "";
+      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefMeanBiomass.TabIndex = 6;
+      // 
+      // checkBoxEnableRefpoints
+      // 
+      this.checkBoxEnableRefpoints.AutoSize = true;
+      this.checkBoxEnableRefpoints.Location = new System.Drawing.Point(22, 19);
+      this.checkBoxEnableRefpoints.Name = "checkBoxEnableRefpoints";
+      this.checkBoxEnableRefpoints.Size = new System.Drawing.Size(224, 17);
+      this.checkBoxEnableRefpoints.TabIndex = 0;
+      this.checkBoxEnableRefpoints.Text = "Enable Reference Point Threshold Report";
+      this.checkBoxEnableRefpoints.UseVisualStyleBackColor = true;
+      this.checkBoxEnableRefpoints.CheckedChanged += new System.EventHandler(this.CheckBoxRefpoints_CheckedChanged);
+      // 
+      // labelMeanBiomass
+      // 
+      this.labelMeanBiomass.AutoSize = true;
+      this.labelMeanBiomass.Enabled = false;
+      this.labelMeanBiomass.Location = new System.Drawing.Point(19, 97);
+      this.labelMeanBiomass.Name = "labelMeanBiomass";
+      this.labelMeanBiomass.Size = new System.Drawing.Size(101, 13);
+      this.labelMeanBiomass.TabIndex = 5;
+      this.labelMeanBiomass.Text = "Mean Biomass (MT)";
+      // 
+      // textBoxRefJan1Biomass
+      // 
+      this.textBoxRefJan1Biomass.Enabled = false;
+      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
+      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
+      this.textBoxRefJan1Biomass.ParamName = null;
+      this.textBoxRefJan1Biomass.PrevValidValue = "";
+      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefJan1Biomass.TabIndex = 4;
+      // 
+      // labelJan1Biomass
+      // 
+      this.labelJan1Biomass.AutoSize = true;
+      this.labelJan1Biomass.Enabled = false;
+      this.labelJan1Biomass.Location = new System.Drawing.Point(19, 71);
+      this.labelJan1Biomass.Name = "labelJan1Biomass";
+      this.labelJan1Biomass.Size = new System.Drawing.Size(131, 13);
+      this.labelJan1Biomass.TabIndex = 3;
+      this.labelJan1Biomass.Text = "Jan-1 Stock Biomass (MT)";
+      // 
+      // textBoxRefSpawnBiomass
+      // 
+      this.textBoxRefSpawnBiomass.Enabled = false;
+      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
+      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
+      this.textBoxRefSpawnBiomass.ParamName = null;
+      this.textBoxRefSpawnBiomass.PrevValidValue = "";
+      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefSpawnBiomass.TabIndex = 2;
+      // 
+      // labelSpawnBiomass
+      // 
+      this.labelSpawnBiomass.AutoSize = true;
+      this.labelSpawnBiomass.Enabled = false;
+      this.labelSpawnBiomass.Location = new System.Drawing.Point(19, 45);
+      this.labelSpawnBiomass.Name = "labelSpawnBiomass";
+      this.labelSpawnBiomass.Size = new System.Drawing.Size(152, 13);
+      this.labelSpawnBiomass.TabIndex = 1;
+      this.labelSpawnBiomass.Text = "Spawning Stock Biomass (MT)";
+      // 
+      // groupBounds
+      // 
+      this.groupBounds.Controls.Add(this.textBoxBoundsNatMortality);
+      this.groupBounds.Controls.Add(this.labelBoundsNatMortality);
+      this.groupBounds.Controls.Add(this.textBoxBoundsMaxWeight);
+      this.groupBounds.Controls.Add(this.labelBoundsMaxWeight);
+      this.groupBounds.Controls.Add(this.checkBoxBounds);
+      this.groupBounds.Location = new System.Drawing.Point(402, 15);
+      this.groupBounds.Name = "groupBounds";
+      this.groupBounds.Size = new System.Drawing.Size(353, 99);
+      this.groupBounds.TabIndex = 3;
+      this.groupBounds.TabStop = false;
+      this.groupBounds.Text = "Bounds";
+      // 
+      // textBoxBoundsNatMortality
+      // 
+      this.textBoxBoundsNatMortality.Enabled = false;
+      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
+      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
+      this.textBoxBoundsNatMortality.ParamName = null;
+      this.textBoxBoundsNatMortality.PrevValidValue = "";
+      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsNatMortality.TabIndex = 4;
+      this.textBoxBoundsNatMortality.Text = "1.0";
+      // 
+      // labelBoundsNatMortality
+      // 
+      this.labelBoundsNatMortality.AutoSize = true;
+      this.labelBoundsNatMortality.Enabled = false;
+      this.labelBoundsNatMortality.Location = new System.Drawing.Point(15, 71);
+      this.labelBoundsNatMortality.Name = "labelBoundsNatMortality";
+      this.labelBoundsNatMortality.Size = new System.Drawing.Size(130, 13);
+      this.labelBoundsNatMortality.TabIndex = 3;
+      this.labelBoundsNatMortality.Text = "Maximum Natural Mortality";
+      // 
+      // textBoxBoundsMaxWeight
+      // 
+      this.textBoxBoundsMaxWeight.Enabled = false;
+      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
+      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
+      this.textBoxBoundsMaxWeight.ParamName = null;
+      this.textBoxBoundsMaxWeight.PrevValidValue = "";
+      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsMaxWeight.TabIndex = 2;
+      this.textBoxBoundsMaxWeight.Text = "10.0";
+      // 
+      // labelBoundsMaxWeight
+      // 
+      this.labelBoundsMaxWeight.AutoSize = true;
+      this.labelBoundsMaxWeight.Enabled = false;
+      this.labelBoundsMaxWeight.Location = new System.Drawing.Point(15, 45);
+      this.labelBoundsMaxWeight.Name = "labelBoundsMaxWeight";
+      this.labelBoundsMaxWeight.Size = new System.Drawing.Size(109, 13);
+      this.labelBoundsMaxWeight.TabIndex = 1;
+      this.labelBoundsMaxWeight.Text = "Maximum Weight (kg)";
+      // 
+      // checkBoxBounds
+      // 
+      this.checkBoxBounds.AutoSize = true;
+      this.checkBoxBounds.Location = new System.Drawing.Point(18, 19);
+      this.checkBoxBounds.Name = "checkBoxBounds";
+      this.checkBoxBounds.Size = new System.Drawing.Size(100, 17);
+      this.checkBoxBounds.TabIndex = 0;
+      this.checkBoxBounds.Text = "Specify Bounds";
+      this.checkBoxBounds.UseVisualStyleBackColor = true;
+      this.checkBoxBounds.CheckedChanged += new System.EventHandler(this.CheckBoxBounds_CheckedChanged);
+      // 
+      // groupScaleFactors
+      // 
+      this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorRecruits);
+      this.groupScaleFactors.Controls.Add(this.labelScaleFactorRecruits);
+      this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorsStockNum);
+      this.groupScaleFactors.Controls.Add(this.labelScaleFactorStockNum);
+      this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorBiomass);
+      this.groupScaleFactors.Controls.Add(this.labelScaleFactorBiomass);
+      this.groupScaleFactors.Controls.Add(this.checkBoxEnableScaleFactors);
+      this.groupScaleFactors.Location = new System.Drawing.Point(29, 350);
+      this.groupScaleFactors.Name = "groupScaleFactors";
+      this.groupScaleFactors.Size = new System.Drawing.Size(353, 136);
+      this.groupScaleFactors.TabIndex = 2;
+      this.groupScaleFactors.TabStop = false;
+      this.groupScaleFactors.Text = "Scaling Factors for Output Report";
+      // 
+      // textBoxScaleFactorRecruits
+      // 
+      this.textBoxScaleFactorRecruits.Enabled = false;
+      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(144, 74);
+      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
+      this.textBoxScaleFactorRecruits.ParamName = null;
+      this.textBoxScaleFactorRecruits.PrevValidValue = "";
+      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorRecruits.TabIndex = 4;
+      // 
+      // labelScaleFactorRecruits
+      // 
+      this.labelScaleFactorRecruits.AutoSize = true;
+      this.labelScaleFactorRecruits.Enabled = false;
+      this.labelScaleFactorRecruits.Location = new System.Drawing.Point(20, 77);
+      this.labelScaleFactorRecruits.Name = "labelScaleFactorRecruits";
+      this.labelScaleFactorRecruits.Size = new System.Drawing.Size(46, 13);
+      this.labelScaleFactorRecruits.TabIndex = 3;
+      this.labelScaleFactorRecruits.Text = "Recruits";
+      // 
+      // textBoxScaleFactorsStockNum
+      // 
+      this.textBoxScaleFactorsStockNum.Enabled = false;
+      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(144, 100);
+      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
+      this.textBoxScaleFactorsStockNum.ParamName = null;
+      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
+      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorsStockNum.TabIndex = 6;
+      // 
+      // labelScaleFactorStockNum
+      // 
+      this.labelScaleFactorStockNum.AutoSize = true;
+      this.labelScaleFactorStockNum.Enabled = false;
+      this.labelScaleFactorStockNum.Location = new System.Drawing.Point(19, 103);
+      this.labelScaleFactorStockNum.Name = "labelScaleFactorStockNum";
+      this.labelScaleFactorStockNum.Size = new System.Drawing.Size(80, 13);
+      this.labelScaleFactorStockNum.TabIndex = 5;
+      this.labelScaleFactorStockNum.Text = "Stock Numbers";
+      // 
+      // textBoxScaleFactorBiomass
+      // 
+      this.textBoxScaleFactorBiomass.Enabled = false;
+      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(144, 48);
+      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
+      this.textBoxScaleFactorBiomass.ParamName = null;
+      this.textBoxScaleFactorBiomass.PrevValidValue = "";
+      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorBiomass.TabIndex = 2;
+      // 
+      // labelScaleFactorBiomass
+      // 
+      this.labelScaleFactorBiomass.AutoSize = true;
+      this.labelScaleFactorBiomass.Enabled = false;
+      this.labelScaleFactorBiomass.Location = new System.Drawing.Point(20, 51);
+      this.labelScaleFactorBiomass.Name = "labelScaleFactorBiomass";
+      this.labelScaleFactorBiomass.Size = new System.Drawing.Size(46, 13);
+      this.labelScaleFactorBiomass.TabIndex = 1;
+      this.labelScaleFactorBiomass.Text = "Biomass";
+      // 
+      // checkBoxEnableScaleFactors
+      // 
+      this.checkBoxEnableScaleFactors.AutoSize = true;
+      this.checkBoxEnableScaleFactors.Location = new System.Drawing.Point(22, 20);
+      this.checkBoxEnableScaleFactors.Name = "checkBoxEnableScaleFactors";
+      this.checkBoxEnableScaleFactors.Size = new System.Drawing.Size(233, 17);
+      this.checkBoxEnableScaleFactors.TabIndex = 0;
+      this.checkBoxEnableScaleFactors.Text = "Specify Scale Factors for Output Report File";
+      this.checkBoxEnableScaleFactors.UseVisualStyleBackColor = true;
+      this.checkBoxEnableScaleFactors.CheckedChanged += new System.EventHandler(this.CheckBoxScaleFactors_CheckedChanged);
+      // 
+      // groupRetroAdjustment
+      // 
+      this.groupRetroAdjustment.Controls.Add(this.checkBoxEnableRetroAdjustment);
+      this.groupRetroAdjustment.Controls.Add(this.dataGridRetroAdjustment);
+      this.groupRetroAdjustment.Location = new System.Drawing.Point(403, 120);
+      this.groupRetroAdjustment.Name = "groupRetroAdjustment";
+      this.groupRetroAdjustment.Size = new System.Drawing.Size(352, 266);
+      this.groupRetroAdjustment.TabIndex = 4;
+      this.groupRetroAdjustment.TabStop = false;
+      this.groupRetroAdjustment.Text = "Retrospective Adjustment Factors";
+      // 
+      // checkBoxEnableRetroAdjustment
+      // 
+      this.checkBoxEnableRetroAdjustment.AutoSize = true;
+      this.checkBoxEnableRetroAdjustment.Location = new System.Drawing.Point(17, 20);
+      this.checkBoxEnableRetroAdjustment.Name = "checkBoxEnableRetroAdjustment";
+      this.checkBoxEnableRetroAdjustment.Size = new System.Drawing.Size(223, 17);
+      this.checkBoxEnableRetroAdjustment.TabIndex = 1;
+      this.checkBoxEnableRetroAdjustment.Text = "Specify Retrospective Adjustment Factors";
+      this.checkBoxEnableRetroAdjustment.UseVisualStyleBackColor = true;
+      this.checkBoxEnableRetroAdjustment.CheckedChanged += new System.EventHandler(this.CheckBoxRetroAdjustment_CheckedChanged);
+      // 
+      // dataGridRetroAdjustment
+      // 
+      this.dataGridRetroAdjustment.AllowUserToAddRows = false;
+      this.dataGridRetroAdjustment.AllowUserToDeleteRows = false;
+      this.dataGridRetroAdjustment.AllowUserToResizeRows = false;
+      this.dataGridRetroAdjustment.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
+      this.dataGridRetroAdjustment.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+      this.dataGridRetroAdjustment.ColumnHeadersVisible = false;
+      this.dataGridRetroAdjustment.Location = new System.Drawing.Point(17, 40);
+      this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
+      this.dataGridRetroAdjustment.nftReadOnly = false;
+      this.dataGridRetroAdjustment.RowHeadersWidth = 75;
+      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(329, 220);
+      this.dataGridRetroAdjustment.TabIndex = 0;
+      this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
+      // 
+      // groupOutputViewer
+      // 
+      this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
+      this.groupOutputViewer.Controls.Add(this.labelOutputViewerProgram);
+      this.groupOutputViewer.Location = new System.Drawing.Point(403, 392);
+      this.groupOutputViewer.Name = "groupOutputViewer";
+      this.groupOutputViewer.Size = new System.Drawing.Size(352, 75);
+      this.groupOutputViewer.TabIndex = 5;
+      this.groupOutputViewer.TabStop = false;
+      this.groupOutputViewer.Text = "Output File Viewer";
+      // 
+      // comboBoxOutputViewerProgram
+      // 
+      this.comboBoxOutputViewerProgram.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.comboBoxOutputViewerProgram.Items.AddRange(new object[] {
             "System Default",
             "Notepad",
             "None"});
-            this.comboBoxOutputViewerProgram.Location = new System.Drawing.Point(17, 39);
-            this.comboBoxOutputViewerProgram.Name = "comboBoxOutputViewerProgram";
-            this.comboBoxOutputViewerProgram.Size = new System.Drawing.Size(318, 21);
-            this.comboBoxOutputViewerProgram.TabIndex = 1;
-            // 
-            // labelOutputViewerProgram
-            // 
-            this.labelOutputViewerProgram.AutoSize = true;
-            this.labelOutputViewerProgram.Location = new System.Drawing.Point(14, 23);
-            this.labelOutputViewerProgram.Name = "labelOutputViewerProgram";
-            this.labelOutputViewerProgram.Size = new System.Drawing.Size(189, 13);
-            this.labelOutputViewerProgram.TabIndex = 0;
-            this.labelOutputViewerProgram.Text = "Program to View AGEPRO Output File ";
-            // 
-            // ControlMiscOptions
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.groupOutputViewer);
-            this.Controls.Add(this.groupRetroAdjustment);
-            this.Controls.Add(this.groupScaleFactors);
-            this.Controls.Add(this.groupBounds);
-            this.Controls.Add(this.groupRefpoints);
-            this.Controls.Add(this.groupOuputOptions);
-            this.Name = "ControlMiscOptions";
-            this.Size = new System.Drawing.Size(900, 520);
-            this.groupOuputOptions.ResumeLayout(false);
-            this.groupOuputOptions.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).EndInit();
-            this.groupRefpoints.ResumeLayout(false);
-            this.groupRefpoints.PerformLayout();
-            this.groupBounds.ResumeLayout(false);
-            this.groupBounds.PerformLayout();
-            this.groupScaleFactors.ResumeLayout(false);
-            this.groupScaleFactors.PerformLayout();
-            this.groupRetroAdjustment.ResumeLayout(false);
-            this.groupRetroAdjustment.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
-            this.groupOutputViewer.ResumeLayout(false);
-            this.groupOutputViewer.PerformLayout();
-            this.ResumeLayout(false);
+      this.comboBoxOutputViewerProgram.Location = new System.Drawing.Point(17, 39);
+      this.comboBoxOutputViewerProgram.Name = "comboBoxOutputViewerProgram";
+      this.comboBoxOutputViewerProgram.Size = new System.Drawing.Size(318, 21);
+      this.comboBoxOutputViewerProgram.TabIndex = 1;
+      // 
+      // labelOutputViewerProgram
+      // 
+      this.labelOutputViewerProgram.AutoSize = true;
+      this.labelOutputViewerProgram.Location = new System.Drawing.Point(14, 23);
+      this.labelOutputViewerProgram.Name = "labelOutputViewerProgram";
+      this.labelOutputViewerProgram.Size = new System.Drawing.Size(189, 13);
+      this.labelOutputViewerProgram.TabIndex = 0;
+      this.labelOutputViewerProgram.Text = "Program to View AGEPRO Output File ";
+      // 
+      // ControlMiscOptions
+      // 
+      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+      this.Controls.Add(this.groupOutputViewer);
+      this.Controls.Add(this.groupRetroAdjustment);
+      this.Controls.Add(this.groupScaleFactors);
+      this.Controls.Add(this.groupBounds);
+      this.Controls.Add(this.groupRefpoints);
+      this.Controls.Add(this.groupOuputOptions);
+      this.Name = "ControlMiscOptions";
+      this.Size = new System.Drawing.Size(900, 520);
+      this.groupOuputOptions.ResumeLayout(false);
+      this.groupOuputOptions.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).EndInit();
+      this.groupRefpoints.ResumeLayout(false);
+      this.groupRefpoints.PerformLayout();
+      this.groupBounds.ResumeLayout(false);
+      this.groupBounds.PerformLayout();
+      this.groupScaleFactors.ResumeLayout(false);
+      this.groupScaleFactors.PerformLayout();
+      this.groupRetroAdjustment.ResumeLayout(false);
+      this.groupRetroAdjustment.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
+      this.groupOutputViewer.ResumeLayout(false);
+      this.groupOutputViewer.PerformLayout();
+      this.ResumeLayout(false);
 
         }
 

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -90,10 +90,10 @@
       this.groupOuputOptions.Controls.Add(this.checkBoxEnablePercentileReport);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableExportR);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableAuxStochasticFiles);
-      this.groupOuputOptions.Location = new System.Drawing.Point(29, 154);
+      this.groupOuputOptions.Location = new System.Drawing.Point(29, 15);
       this.groupOuputOptions.Name = "groupOuputOptions";
       this.groupOuputOptions.Size = new System.Drawing.Size(406, 123);
-      this.groupOuputOptions.TabIndex = 1;
+      this.groupOuputOptions.TabIndex = 0;
       this.groupOuputOptions.TabStop = false;
       this.groupOuputOptions.Text = "Output Options";
       // 
@@ -161,7 +161,7 @@
       this.groupRefpoints.Location = new System.Drawing.Point(441, 219);
       this.groupRefpoints.Name = "groupRefpoints";
       this.groupRefpoints.Size = new System.Drawing.Size(390, 152);
-      this.groupRefpoints.TabIndex = 5;
+      this.groupRefpoints.TabIndex = 7;
       this.groupRefpoints.TabStop = false;
       this.groupRefpoints.Text = "Reference Points";
       // 
@@ -226,7 +226,7 @@
       this.groupBounds.Location = new System.Drawing.Point(441, 114);
       this.groupBounds.Name = "groupBounds";
       this.groupBounds.Size = new System.Drawing.Size(390, 99);
-      this.groupBounds.TabIndex = 4;
+      this.groupBounds.TabIndex = 6;
       this.groupBounds.TabStop = false;
       this.groupBounds.Text = "Bounds";
       // 
@@ -273,7 +273,7 @@
       this.groupScaleFactors.Location = new System.Drawing.Point(441, 377);
       this.groupScaleFactors.Name = "groupScaleFactors";
       this.groupScaleFactors.Size = new System.Drawing.Size(390, 128);
-      this.groupScaleFactors.TabIndex = 6;
+      this.groupScaleFactors.TabIndex = 8;
       this.groupScaleFactors.TabStop = false;
       this.groupScaleFactors.Text = "Scaling Factors for Output Report";
       // 
@@ -322,9 +322,9 @@
       // 
       this.groupRetroAdjustment.Controls.Add(this.checkBoxEnableRetroAdjustment);
       this.groupRetroAdjustment.Controls.Add(this.dataGridRetroAdjustment);
-      this.groupRetroAdjustment.Location = new System.Drawing.Point(29, 283);
+      this.groupRetroAdjustment.Location = new System.Drawing.Point(29, 290);
       this.groupRetroAdjustment.Name = "groupRetroAdjustment";
-      this.groupRetroAdjustment.Size = new System.Drawing.Size(406, 223);
+      this.groupRetroAdjustment.Size = new System.Drawing.Size(406, 216);
       this.groupRetroAdjustment.TabIndex = 2;
       this.groupRetroAdjustment.TabStop = false;
       this.groupRetroAdjustment.Text = "Retrospective Adjustment Factors";
@@ -368,70 +368,70 @@
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockAge_NoAux);
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockAge_AllAux);
       this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockAge_ExcludeStockNumAux);
-      this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
+      this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 144);
       this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
-      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(406, 133);
-      this.groupBox_StockSummmaryFlag.TabIndex = 0;
+      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(406, 140);
+      this.groupBox_StockSummmaryFlag.TabIndex = 1;
       this.groupBox_StockSummmaryFlag.TabStop = false;
-      this.groupBox_StockSummmaryFlag.Text = "Stock Distribution Summary and Auxiliary Data Files";
+      this.groupBox_StockSummmaryFlag.Text = "Stock Of Age Distribution and Auxiliary Files Output";
       // 
       // radioButtonStockAge_ExcludeStockNumAux
       // 
       this.radioButtonStockAge_ExcludeStockNumAux.AutoSize = true;
-      this.radioButtonStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 109);
+      this.radioButtonStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 114);
       this.radioButtonStockAge_ExcludeStockNumAux.Name = "radioButtonStockAge_ExcludeStockNumAux";
-      this.radioButtonStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(302, 17);
+      this.radioButtonStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(368, 17);
       this.radioButtonStockAge_ExcludeStockNumAux.TabIndex = 4;
       this.radioButtonStockAge_ExcludeStockNumAux.TabStop = true;
-      this.radioButtonStockAge_ExcludeStockNumAux.Text = "Output Stock Of Age, Auxiliary Files EXCEPT Stock of Age";
+      this.radioButtonStockAge_ExcludeStockNumAux.Text = "Output Stock Of Age, and Auxiliary Files EXCEPT Stock Numbers of Age";
       this.radioButtonStockAge_ExcludeStockNumAux.UseVisualStyleBackColor = true;
       this.radioButtonStockAge_ExcludeStockNumAux.CheckedChanged += new System.EventHandler(this.radioButtonStockAge_ExcludeStockNumAux_CheckedChanged);
       // 
       // radioButtonStockAge_NoAux
       // 
       this.radioButtonStockAge_NoAux.AutoSize = true;
-      this.radioButtonStockAge_NoAux.Location = new System.Drawing.Point(17, 86);
+      this.radioButtonStockAge_NoAux.Location = new System.Drawing.Point(17, 91);
       this.radioButtonStockAge_NoAux.Name = "radioButtonStockAge_NoAux";
-      this.radioButtonStockAge_NoAux.Size = new System.Drawing.Size(211, 17);
+      this.radioButtonStockAge_NoAux.Size = new System.Drawing.Size(229, 17);
       this.radioButtonStockAge_NoAux.TabIndex = 3;
       this.radioButtonStockAge_NoAux.TabStop = true;
-      this.radioButtonStockAge_NoAux.Text = "Ouptut Stock Of Age, NO Auxiilary Files";
+      this.radioButtonStockAge_NoAux.Text = "Ouptut Stock Of Age, but NO Auxiilary Files";
       this.radioButtonStockAge_NoAux.UseVisualStyleBackColor = true;
       this.radioButtonStockAge_NoAux.CheckedChanged += new System.EventHandler(this.radioButtonStockAge_NoAux_CheckedChanged);
       // 
       // radioButtonNoStockAge_NoAux
       // 
       this.radioButtonNoStockAge_NoAux.AutoSize = true;
-      this.radioButtonNoStockAge_NoAux.Location = new System.Drawing.Point(17, 63);
+      this.radioButtonNoStockAge_NoAux.Location = new System.Drawing.Point(17, 68);
       this.radioButtonNoStockAge_NoAux.Name = "radioButtonNoStockAge_NoAux";
-      this.radioButtonNoStockAge_NoAux.Size = new System.Drawing.Size(194, 17);
+      this.radioButtonNoStockAge_NoAux.Size = new System.Drawing.Size(199, 17);
       this.radioButtonNoStockAge_NoAux.TabIndex = 2;
       this.radioButtonNoStockAge_NoAux.TabStop = true;
-      this.radioButtonNoStockAge_NoAux.Text = "NO Stock Of Age and Auxiliary Files";
+      this.radioButtonNoStockAge_NoAux.Text = "NO Stock Of Age AND Auxiliary Files";
       this.radioButtonNoStockAge_NoAux.UseVisualStyleBackColor = true;
       this.radioButtonNoStockAge_NoAux.CheckedChanged += new System.EventHandler(this.radioButtonNoStockAge_NoAux_CheckedChanged);
       // 
       // radioButtonStockAge_AllAux
       // 
       this.radioButtonStockAge_AllAux.AutoSize = true;
-      this.radioButtonStockAge_AllAux.Location = new System.Drawing.Point(17, 40);
+      this.radioButtonStockAge_AllAux.Location = new System.Drawing.Point(17, 45);
       this.radioButtonStockAge_AllAux.Name = "radioButtonStockAge_AllAux";
-      this.radioButtonStockAge_AllAux.Size = new System.Drawing.Size(234, 17);
+      this.radioButtonStockAge_AllAux.Size = new System.Drawing.Size(229, 17);
       this.radioButtonStockAge_AllAux.TabIndex = 1;
       this.radioButtonStockAge_AllAux.TabStop = true;
-      this.radioButtonStockAge_AllAux.Text = "Output Stock Of Age AND ALL Auxiliary files";
+      this.radioButtonStockAge_AllAux.Text = "Output Stock Of Age AND All Auxiliary Files";
       this.radioButtonStockAge_AllAux.UseVisualStyleBackColor = true;
       this.radioButtonStockAge_AllAux.CheckedChanged += new System.EventHandler(this.radioButtonStockAge_AllAux_CheckedChanged);
       // 
       // radioButtonNoStockAge_ExcludeStockNumAux
       // 
       this.radioButtonNoStockAge_ExcludeStockNumAux.AutoSize = true;
-      this.radioButtonNoStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 17);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Location = new System.Drawing.Point(17, 22);
       this.radioButtonNoStockAge_ExcludeStockNumAux.Name = "radioButtonNoStockAge_ExcludeStockNumAux";
-      this.radioButtonNoStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(359, 17);
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Size = new System.Drawing.Size(380, 17);
       this.radioButtonNoStockAge_ExcludeStockNumAux.TabIndex = 0;
       this.radioButtonNoStockAge_ExcludeStockNumAux.TabStop = true;
-      this.radioButtonNoStockAge_ExcludeStockNumAux.Text = "No Stock of Age, Output Auxiliary files EXCEPT Stock Numbers of Age";
+      this.radioButtonNoStockAge_ExcludeStockNumAux.Text = "No Stock of Age, but Output Auxiliary Files EXCEPT Stock Numbers of Age";
       this.radioButtonNoStockAge_ExcludeStockNumAux.UseVisualStyleBackColor = true;
       this.radioButtonNoStockAge_ExcludeStockNumAux.CheckedChanged += new System.EventHandler(this.radioButtonNoStockAge_ExcludeStockNumAux_CheckedChanged);
       // 
@@ -442,7 +442,7 @@
       this.groupOutputViewer.Location = new System.Drawing.Point(441, 45);
       this.groupOutputViewer.Name = "groupOutputViewer";
       this.groupOutputViewer.Size = new System.Drawing.Size(390, 65);
-      this.groupOutputViewer.TabIndex = 3;
+      this.groupOutputViewer.TabIndex = 5;
       this.groupOutputViewer.TabStop = false;
       this.groupOutputViewer.Text = "Output File Viewer";
       // 
@@ -452,7 +452,7 @@
       this.checkBoxEnableVer40Format.Location = new System.Drawing.Point(442, 22);
       this.checkBoxEnableVer40Format.Name = "checkBoxEnableVer40Format";
       this.checkBoxEnableVer40Format.Size = new System.Drawing.Size(256, 17);
-      this.checkBoxEnableVer40Format.TabIndex = 7;
+      this.checkBoxEnableVer40Format.TabIndex = 3;
       this.checkBoxEnableVer40Format.Text = "Enable AGEPRO VERSION 4.0 input File Format";
       this.checkBoxEnableVer40Format.UseVisualStyleBackColor = true;
       this.checkBoxEnableVer40Format.CheckedChanged += new System.EventHandler(this.checkBoxEnableVer40Format_CheckedChanged);
@@ -468,7 +468,7 @@
       this.textBoxMiscOptionsInpfileVerString.ParamName = null;
       this.textBoxMiscOptionsInpfileVerString.PrevValidValue = "";
       this.textBoxMiscOptionsInpfileVerString.Size = new System.Drawing.Size(127, 13);
-      this.textBoxMiscOptionsInpfileVerString.TabIndex = 8;
+      this.textBoxMiscOptionsInpfileVerString.TabIndex = 4;
       this.textBoxMiscOptionsInpfileVerString.Text = "AGEPRO VERSION";
       // 
       // dataGridRetroAdjustment
@@ -483,7 +483,7 @@
       this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
       this.dataGridRetroAdjustment.nftReadOnly = false;
       this.dataGridRetroAdjustment.RowHeadersWidth = 75;
-      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 171);
+      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 165);
       this.dataGridRetroAdjustment.TabIndex = 0;
       this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
       // 

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -55,10 +55,10 @@
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
       this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
-      this.radioButton_None = new System.Windows.Forms.RadioButton();
-      this.radioButton_SummaryOnly = new System.Windows.Forms.RadioButton();
-      this.radioButton_SummaryNoAux1 = new System.Windows.Forms.RadioButton();
       this.radioButton_SummaryPlusAllAux = new System.Windows.Forms.RadioButton();
+      this.radioButton_SummaryNoAux1 = new System.Windows.Forms.RadioButton();
+      this.radioButton_SummaryOnly = new System.Windows.Forms.RadioButton();
+      this.radioButton_None = new System.Windows.Forms.RadioButton();
       this.groupOutputViewer = new System.Windows.Forms.GroupBox();
       this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
       this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
@@ -91,7 +91,7 @@
       this.groupOuputOptions.Location = new System.Drawing.Point(29, 144);
       this.groupOuputOptions.Name = "groupOuputOptions";
       this.groupOuputOptions.Size = new System.Drawing.Size(383, 123);
-      this.groupOuputOptions.TabIndex = 0;
+      this.groupOuputOptions.TabIndex = 1;
       this.groupOuputOptions.TabStop = false;
       this.groupOuputOptions.Text = "Output Options";
       // 
@@ -141,7 +141,7 @@
       this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(17, 19);
       this.checkBoxEnableAuxStochasticFiles.Name = "checkBoxEnableAuxStochasticFiles";
       this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(214, 17);
-      this.checkBoxEnableAuxStochasticFiles.TabIndex = 1;
+      this.checkBoxEnableAuxStochasticFiles.TabIndex = 4;
       this.checkBoxEnableAuxStochasticFiles.Text = "Generate Auxiliary Stochastic Data Files";
       this.checkBoxEnableAuxStochasticFiles.UseVisualStyleBackColor = true;
       // 
@@ -151,7 +151,7 @@
       this.checkBoxEnableSummaryReport.Location = new System.Drawing.Point(418, 489);
       this.checkBoxEnableSummaryReport.Name = "checkBoxEnableSummaryReport";
       this.checkBoxEnableSummaryReport.Size = new System.Drawing.Size(262, 17);
-      this.checkBoxEnableSummaryReport.TabIndex = 0;
+      this.checkBoxEnableSummaryReport.TabIndex = 7;
       this.checkBoxEnableSummaryReport.Text = "Output Summary Report of Stock Numbers At Age";
       this.checkBoxEnableSummaryReport.UseVisualStyleBackColor = true;
       // 
@@ -169,7 +169,7 @@
       this.groupRefpoints.Location = new System.Drawing.Point(418, 191);
       this.groupRefpoints.Name = "groupRefpoints";
       this.groupRefpoints.Size = new System.Drawing.Size(390, 152);
-      this.groupRefpoints.TabIndex = 1;
+      this.groupRefpoints.TabIndex = 5;
       this.groupRefpoints.TabStop = false;
       this.groupRefpoints.Text = "Reference Points";
       // 
@@ -234,7 +234,7 @@
       this.groupBounds.Location = new System.Drawing.Point(418, 86);
       this.groupBounds.Name = "groupBounds";
       this.groupBounds.Size = new System.Drawing.Size(390, 99);
-      this.groupBounds.TabIndex = 3;
+      this.groupBounds.TabIndex = 4;
       this.groupBounds.TabStop = false;
       this.groupBounds.Text = "Bounds";
       // 
@@ -281,7 +281,7 @@
       this.groupScaleFactors.Location = new System.Drawing.Point(418, 349);
       this.groupScaleFactors.Name = "groupScaleFactors";
       this.groupScaleFactors.Size = new System.Drawing.Size(390, 134);
-      this.groupScaleFactors.TabIndex = 2;
+      this.groupScaleFactors.TabIndex = 6;
       this.groupScaleFactors.TabStop = false;
       this.groupScaleFactors.Text = "Scaling Factors for Output Report";
       // 
@@ -333,7 +333,7 @@
       this.groupRetroAdjustment.Location = new System.Drawing.Point(29, 273);
       this.groupRetroAdjustment.Name = "groupRetroAdjustment";
       this.groupRetroAdjustment.Size = new System.Drawing.Size(383, 223);
-      this.groupRetroAdjustment.TabIndex = 4;
+      this.groupRetroAdjustment.TabIndex = 2;
       this.groupRetroAdjustment.TabStop = false;
       this.groupRetroAdjustment.Text = "Retrospective Adjustment Factors";
       // 
@@ -378,42 +378,9 @@
       this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
       this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
       this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(383, 123);
-      this.groupBox_StockSummmaryFlag.TabIndex = 5;
+      this.groupBox_StockSummmaryFlag.TabIndex = 0;
       this.groupBox_StockSummmaryFlag.TabStop = false;
       this.groupBox_StockSummmaryFlag.Text = "Stock Summary Ouptut and Auxiliary Data Files";
-      // 
-      // radioButton_None
-      // 
-      this.radioButton_None.AutoSize = true;
-      this.radioButton_None.Location = new System.Drawing.Point(17, 17);
-      this.radioButton_None.Name = "radioButton_None";
-      this.radioButton_None.Size = new System.Drawing.Size(51, 17);
-      this.radioButton_None.TabIndex = 0;
-      this.radioButton_None.TabStop = true;
-      this.radioButton_None.Text = "None";
-      this.radioButton_None.UseVisualStyleBackColor = true;
-      // 
-      // radioButton_SummaryOnly
-      // 
-      this.radioButton_SummaryOnly.AutoSize = true;
-      this.radioButton_SummaryOnly.Location = new System.Drawing.Point(17, 40);
-      this.radioButton_SummaryOnly.Name = "radioButton_SummaryOnly";
-      this.radioButton_SummaryOnly.Size = new System.Drawing.Size(92, 17);
-      this.radioButton_SummaryOnly.TabIndex = 1;
-      this.radioButton_SummaryOnly.TabStop = true;
-      this.radioButton_SummaryOnly.Text = "Summary Only";
-      this.radioButton_SummaryOnly.UseVisualStyleBackColor = true;
-      // 
-      // radioButton_SummaryNoAux1
-      // 
-      this.radioButton_SummaryNoAux1.AutoSize = true;
-      this.radioButton_SummaryNoAux1.Location = new System.Drawing.Point(17, 63);
-      this.radioButton_SummaryNoAux1.Name = "radioButton_SummaryNoAux1";
-      this.radioButton_SummaryNoAux1.Size = new System.Drawing.Size(292, 17);
-      this.radioButton_SummaryNoAux1.TabIndex = 2;
-      this.radioButton_SummaryNoAux1.TabStop = true;
-      this.radioButton_SummaryNoAux1.Text = "Summary Plus Auxiliary Files EXCLUDING Stock Aux File";
-      this.radioButton_SummaryNoAux1.UseVisualStyleBackColor = true;
       // 
       // radioButton_SummaryPlusAllAux
       // 
@@ -426,6 +393,39 @@
       this.radioButton_SummaryPlusAllAux.Text = "Summary Plus All Auxiliary Files";
       this.radioButton_SummaryPlusAllAux.UseVisualStyleBackColor = true;
       // 
+      // radioButton_SummaryNoAux1
+      // 
+      this.radioButton_SummaryNoAux1.AutoSize = true;
+      this.radioButton_SummaryNoAux1.Location = new System.Drawing.Point(17, 63);
+      this.radioButton_SummaryNoAux1.Name = "radioButton_SummaryNoAux1";
+      this.radioButton_SummaryNoAux1.Size = new System.Drawing.Size(292, 17);
+      this.radioButton_SummaryNoAux1.TabIndex = 2;
+      this.radioButton_SummaryNoAux1.TabStop = true;
+      this.radioButton_SummaryNoAux1.Text = "Summary Plus Auxiliary Files EXCLUDING Stock Aux File";
+      this.radioButton_SummaryNoAux1.UseVisualStyleBackColor = true;
+      // 
+      // radioButton_SummaryOnly
+      // 
+      this.radioButton_SummaryOnly.AutoSize = true;
+      this.radioButton_SummaryOnly.Location = new System.Drawing.Point(17, 40);
+      this.radioButton_SummaryOnly.Name = "radioButton_SummaryOnly";
+      this.radioButton_SummaryOnly.Size = new System.Drawing.Size(92, 17);
+      this.radioButton_SummaryOnly.TabIndex = 1;
+      this.radioButton_SummaryOnly.TabStop = true;
+      this.radioButton_SummaryOnly.Text = "Summary Only";
+      this.radioButton_SummaryOnly.UseVisualStyleBackColor = true;
+      // 
+      // radioButton_None
+      // 
+      this.radioButton_None.AutoSize = true;
+      this.radioButton_None.Location = new System.Drawing.Point(17, 17);
+      this.radioButton_None.Name = "radioButton_None";
+      this.radioButton_None.Size = new System.Drawing.Size(51, 17);
+      this.radioButton_None.TabIndex = 0;
+      this.radioButton_None.TabStop = true;
+      this.radioButton_None.Text = "None";
+      this.radioButton_None.UseVisualStyleBackColor = true;
+      // 
       // groupOutputViewer
       // 
       this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
@@ -433,7 +433,7 @@
       this.groupOutputViewer.Location = new System.Drawing.Point(418, 15);
       this.groupOutputViewer.Name = "groupOutputViewer";
       this.groupOutputViewer.Size = new System.Drawing.Size(390, 65);
-      this.groupOutputViewer.TabIndex = 6;
+      this.groupOutputViewer.TabIndex = 3;
       this.groupOutputViewer.TabStop = false;
       this.groupOutputViewer.Text = "Output File Viewer";
       // 

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -154,6 +154,7 @@
       this.checkBoxEnableSummaryReport.TabIndex = 7;
       this.checkBoxEnableSummaryReport.Text = "Output Summary Report of Stock Numbers At Age";
       this.checkBoxEnableSummaryReport.UseVisualStyleBackColor = true;
+      this.checkBoxEnableSummaryReport.CheckedChanged += new System.EventHandler(this.CheckBoxEnableSummaryReport_CheckedChanged);
       // 
       // groupRefpoints
       // 
@@ -392,6 +393,7 @@
       this.radioButtonSummaryPlusAllAux.TabStop = true;
       this.radioButtonSummaryPlusAllAux.Text = "Summary Plus All Auxiliary Files";
       this.radioButtonSummaryPlusAllAux.UseVisualStyleBackColor = true;
+      this.radioButtonSummaryPlusAllAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
       // 
       // radioButtonSummaryNoAux1
       // 
@@ -403,6 +405,7 @@
       this.radioButtonSummaryNoAux1.TabStop = true;
       this.radioButtonSummaryNoAux1.Text = "Summary Plus Auxiliary Files EXCLUDING Stock Aux File";
       this.radioButtonSummaryNoAux1.UseVisualStyleBackColor = true;
+      this.radioButtonSummaryNoAux1.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryNoAux1_CheckedChanged);
       // 
       // radioButtonSummaryOnly
       // 
@@ -414,6 +417,7 @@
       this.radioButtonSummaryOnly.TabStop = true;
       this.radioButtonSummaryOnly.Text = "Summary Only";
       this.radioButtonSummaryOnly.UseVisualStyleBackColor = true;
+      this.radioButtonSummaryOnly.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryOnly_CheckedChanged);
       // 
       // radioButtonNone
       // 
@@ -425,6 +429,7 @@
       this.radioButtonNone.TabStop = true;
       this.radioButtonNone.Text = "None";
       this.radioButtonNone.UseVisualStyleBackColor = true;
+      this.radioButtonNone.CheckedChanged += new System.EventHandler(this.RadioButtonNone_CheckedChanged);
       // 
       // groupOutputViewer
       // 

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -36,43 +36,49 @@
       this.checkBoxEnableAuxStochasticFiles = new System.Windows.Forms.CheckBox();
       this.checkBoxEnableSummaryReport = new System.Windows.Forms.CheckBox();
       this.groupRefpoints = new System.Windows.Forms.GroupBox();
-      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelFishMortality = new System.Windows.Forms.Label();
-      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.checkBoxEnableRefpoints = new System.Windows.Forms.CheckBox();
       this.labelMeanBiomass = new System.Windows.Forms.Label();
-      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelJan1Biomass = new System.Windows.Forms.Label();
-      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelSpawnBiomass = new System.Windows.Forms.Label();
       this.groupBounds = new System.Windows.Forms.GroupBox();
-      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsNatMortality = new System.Windows.Forms.Label();
-      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelBoundsMaxWeight = new System.Windows.Forms.Label();
       this.checkBoxBounds = new System.Windows.Forms.CheckBox();
       this.groupScaleFactors = new System.Windows.Forms.GroupBox();
-      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorRecruits = new System.Windows.Forms.Label();
-      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorStockNum = new System.Windows.Forms.Label();
-      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.labelScaleFactorBiomass = new System.Windows.Forms.Label();
       this.checkBoxEnableScaleFactors = new System.Windows.Forms.CheckBox();
       this.groupRetroAdjustment = new System.Windows.Forms.GroupBox();
       this.checkBoxEnableRetroAdjustment = new System.Windows.Forms.CheckBox();
-      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
-      this.groupOutputViewer = new System.Windows.Forms.GroupBox();
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
+      this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
+      this.radioButton_None = new System.Windows.Forms.RadioButton();
+      this.radioButton_SummaryOnly = new System.Windows.Forms.RadioButton();
+      this.radioButton_SummaryNoAux1 = new System.Windows.Forms.RadioButton();
+      this.radioButton_SummaryPlusAllAux = new System.Windows.Forms.RadioButton();
+      this.groupOutputViewer = new System.Windows.Forms.GroupBox();
+      this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
+      this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxScaleFactorsStockNum = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxScaleFactorBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxBoundsNatMortality = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxBoundsMaxWeight = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefFishMortality = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefMeanBiomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefJan1Biomass = new Nmfs.Agepro.Gui.NftTextBox();
+      this.textBoxRefSpawnBiomass = new Nmfs.Agepro.Gui.NftTextBox();
       this.groupOuputOptions.SuspendLayout();
       ((System.ComponentModel.ISupportInitialize)(this.spinBoxReportPercentile)).BeginInit();
       this.groupRefpoints.SuspendLayout();
       this.groupBounds.SuspendLayout();
       this.groupScaleFactors.SuspendLayout();
       this.groupRetroAdjustment.SuspendLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
+      this.groupBox_StockSummmaryFlag.SuspendLayout();
       this.groupOutputViewer.SuspendLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).BeginInit();
       this.SuspendLayout();
       // 
       // groupOuputOptions
@@ -82,10 +88,9 @@
       this.groupOuputOptions.Controls.Add(this.checkBoxEnablePercentileReport);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableExportR);
       this.groupOuputOptions.Controls.Add(this.checkBoxEnableAuxStochasticFiles);
-      this.groupOuputOptions.Controls.Add(this.checkBoxEnableSummaryReport);
-      this.groupOuputOptions.Location = new System.Drawing.Point(29, 15);
+      this.groupOuputOptions.Location = new System.Drawing.Point(29, 144);
       this.groupOuputOptions.Name = "groupOuputOptions";
-      this.groupOuputOptions.Size = new System.Drawing.Size(353, 171);
+      this.groupOuputOptions.Size = new System.Drawing.Size(383, 123);
       this.groupOuputOptions.TabIndex = 0;
       this.groupOuputOptions.TabStop = false;
       this.groupOuputOptions.Text = "Output Options";
@@ -94,7 +99,7 @@
       // 
       this.spinBoxReportPercentile.DecimalPlaces = 1;
       this.spinBoxReportPercentile.Enabled = false;
-      this.spinBoxReportPercentile.Location = new System.Drawing.Point(165, 114);
+      this.spinBoxReportPercentile.Location = new System.Drawing.Point(159, 87);
       this.spinBoxReportPercentile.Name = "spinBoxReportPercentile";
       this.spinBoxReportPercentile.Size = new System.Drawing.Size(107, 20);
       this.spinBoxReportPercentile.TabIndex = 5;
@@ -103,7 +108,7 @@
       // 
       this.labelReportPercentile.AutoSize = true;
       this.labelReportPercentile.Enabled = false;
-      this.labelReportPercentile.Location = new System.Drawing.Point(70, 116);
+      this.labelReportPercentile.Location = new System.Drawing.Point(64, 89);
       this.labelReportPercentile.Name = "labelReportPercentile";
       this.labelReportPercentile.Size = new System.Drawing.Size(89, 13);
       this.labelReportPercentile.TabIndex = 4;
@@ -112,7 +117,7 @@
       // checkBoxEnablePercentileReport
       // 
       this.checkBoxEnablePercentileReport.AutoSize = true;
-      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(23, 92);
+      this.checkBoxEnablePercentileReport.Location = new System.Drawing.Point(17, 65);
       this.checkBoxEnablePercentileReport.Name = "checkBoxEnablePercentileReport";
       this.checkBoxEnablePercentileReport.Size = new System.Drawing.Size(151, 17);
       this.checkBoxEnablePercentileReport.TabIndex = 3;
@@ -123,7 +128,7 @@
       // checkBoxEnableExportR
       // 
       this.checkBoxEnableExportR.AutoSize = true;
-      this.checkBoxEnableExportR.Location = new System.Drawing.Point(23, 69);
+      this.checkBoxEnableExportR.Location = new System.Drawing.Point(17, 42);
       this.checkBoxEnableExportR.Name = "checkBoxEnableExportR";
       this.checkBoxEnableExportR.Size = new System.Drawing.Size(117, 17);
       this.checkBoxEnableExportR.TabIndex = 2;
@@ -133,7 +138,7 @@
       // checkBoxEnableAuxStochasticFiles
       // 
       this.checkBoxEnableAuxStochasticFiles.AutoSize = true;
-      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(23, 46);
+      this.checkBoxEnableAuxStochasticFiles.Location = new System.Drawing.Point(17, 19);
       this.checkBoxEnableAuxStochasticFiles.Name = "checkBoxEnableAuxStochasticFiles";
       this.checkBoxEnableAuxStochasticFiles.Size = new System.Drawing.Size(214, 17);
       this.checkBoxEnableAuxStochasticFiles.TabIndex = 1;
@@ -143,7 +148,7 @@
       // checkBoxEnableSummaryReport
       // 
       this.checkBoxEnableSummaryReport.AutoSize = true;
-      this.checkBoxEnableSummaryReport.Location = new System.Drawing.Point(23, 23);
+      this.checkBoxEnableSummaryReport.Location = new System.Drawing.Point(418, 489);
       this.checkBoxEnableSummaryReport.Name = "checkBoxEnableSummaryReport";
       this.checkBoxEnableSummaryReport.Size = new System.Drawing.Size(262, 17);
       this.checkBoxEnableSummaryReport.TabIndex = 0;
@@ -161,22 +166,12 @@
       this.groupRefpoints.Controls.Add(this.labelJan1Biomass);
       this.groupRefpoints.Controls.Add(this.textBoxRefSpawnBiomass);
       this.groupRefpoints.Controls.Add(this.labelSpawnBiomass);
-      this.groupRefpoints.Location = new System.Drawing.Point(29, 192);
+      this.groupRefpoints.Location = new System.Drawing.Point(418, 191);
       this.groupRefpoints.Name = "groupRefpoints";
-      this.groupRefpoints.Size = new System.Drawing.Size(353, 152);
+      this.groupRefpoints.Size = new System.Drawing.Size(390, 152);
       this.groupRefpoints.TabIndex = 1;
       this.groupRefpoints.TabStop = false;
       this.groupRefpoints.Text = "Reference Points";
-      // 
-      // textBoxRefFishMortality
-      // 
-      this.textBoxRefFishMortality.Enabled = false;
-      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
-      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
-      this.textBoxRefFishMortality.ParamName = null;
-      this.textBoxRefFishMortality.PrevValidValue = "";
-      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefFishMortality.TabIndex = 8;
       // 
       // labelFishMortality
       // 
@@ -187,16 +182,6 @@
       this.labelFishMortality.Size = new System.Drawing.Size(82, 13);
       this.labelFishMortality.TabIndex = 7;
       this.labelFishMortality.Text = "Fishing Mortality";
-      // 
-      // textBoxRefMeanBiomass
-      // 
-      this.textBoxRefMeanBiomass.Enabled = false;
-      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
-      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
-      this.textBoxRefMeanBiomass.ParamName = null;
-      this.textBoxRefMeanBiomass.PrevValidValue = "";
-      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefMeanBiomass.TabIndex = 6;
       // 
       // checkBoxEnableRefpoints
       // 
@@ -219,16 +204,6 @@
       this.labelMeanBiomass.TabIndex = 5;
       this.labelMeanBiomass.Text = "Mean Biomass (MT)";
       // 
-      // textBoxRefJan1Biomass
-      // 
-      this.textBoxRefJan1Biomass.Enabled = false;
-      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
-      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
-      this.textBoxRefJan1Biomass.ParamName = null;
-      this.textBoxRefJan1Biomass.PrevValidValue = "";
-      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefJan1Biomass.TabIndex = 4;
-      // 
       // labelJan1Biomass
       // 
       this.labelJan1Biomass.AutoSize = true;
@@ -238,16 +213,6 @@
       this.labelJan1Biomass.Size = new System.Drawing.Size(131, 13);
       this.labelJan1Biomass.TabIndex = 3;
       this.labelJan1Biomass.Text = "Jan-1 Stock Biomass (MT)";
-      // 
-      // textBoxRefSpawnBiomass
-      // 
-      this.textBoxRefSpawnBiomass.Enabled = false;
-      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
-      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
-      this.textBoxRefSpawnBiomass.ParamName = null;
-      this.textBoxRefSpawnBiomass.PrevValidValue = "";
-      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
-      this.textBoxRefSpawnBiomass.TabIndex = 2;
       // 
       // labelSpawnBiomass
       // 
@@ -266,23 +231,12 @@
       this.groupBounds.Controls.Add(this.textBoxBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.labelBoundsMaxWeight);
       this.groupBounds.Controls.Add(this.checkBoxBounds);
-      this.groupBounds.Location = new System.Drawing.Point(402, 15);
+      this.groupBounds.Location = new System.Drawing.Point(418, 86);
       this.groupBounds.Name = "groupBounds";
-      this.groupBounds.Size = new System.Drawing.Size(353, 99);
+      this.groupBounds.Size = new System.Drawing.Size(390, 99);
       this.groupBounds.TabIndex = 3;
       this.groupBounds.TabStop = false;
       this.groupBounds.Text = "Bounds";
-      // 
-      // textBoxBoundsNatMortality
-      // 
-      this.textBoxBoundsNatMortality.Enabled = false;
-      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
-      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
-      this.textBoxBoundsNatMortality.ParamName = null;
-      this.textBoxBoundsNatMortality.PrevValidValue = "";
-      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
-      this.textBoxBoundsNatMortality.TabIndex = 4;
-      this.textBoxBoundsNatMortality.Text = "1.0";
       // 
       // labelBoundsNatMortality
       // 
@@ -293,17 +247,6 @@
       this.labelBoundsNatMortality.Size = new System.Drawing.Size(130, 13);
       this.labelBoundsNatMortality.TabIndex = 3;
       this.labelBoundsNatMortality.Text = "Maximum Natural Mortality";
-      // 
-      // textBoxBoundsMaxWeight
-      // 
-      this.textBoxBoundsMaxWeight.Enabled = false;
-      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
-      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
-      this.textBoxBoundsMaxWeight.ParamName = null;
-      this.textBoxBoundsMaxWeight.PrevValidValue = "";
-      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
-      this.textBoxBoundsMaxWeight.TabIndex = 2;
-      this.textBoxBoundsMaxWeight.Text = "10.0";
       // 
       // labelBoundsMaxWeight
       // 
@@ -335,22 +278,12 @@
       this.groupScaleFactors.Controls.Add(this.textBoxScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.labelScaleFactorBiomass);
       this.groupScaleFactors.Controls.Add(this.checkBoxEnableScaleFactors);
-      this.groupScaleFactors.Location = new System.Drawing.Point(29, 350);
+      this.groupScaleFactors.Location = new System.Drawing.Point(418, 349);
       this.groupScaleFactors.Name = "groupScaleFactors";
-      this.groupScaleFactors.Size = new System.Drawing.Size(353, 136);
+      this.groupScaleFactors.Size = new System.Drawing.Size(390, 134);
       this.groupScaleFactors.TabIndex = 2;
       this.groupScaleFactors.TabStop = false;
       this.groupScaleFactors.Text = "Scaling Factors for Output Report";
-      // 
-      // textBoxScaleFactorRecruits
-      // 
-      this.textBoxScaleFactorRecruits.Enabled = false;
-      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(144, 74);
-      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
-      this.textBoxScaleFactorRecruits.ParamName = null;
-      this.textBoxScaleFactorRecruits.PrevValidValue = "";
-      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorRecruits.TabIndex = 4;
       // 
       // labelScaleFactorRecruits
       // 
@@ -362,16 +295,6 @@
       this.labelScaleFactorRecruits.TabIndex = 3;
       this.labelScaleFactorRecruits.Text = "Recruits";
       // 
-      // textBoxScaleFactorsStockNum
-      // 
-      this.textBoxScaleFactorsStockNum.Enabled = false;
-      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(144, 100);
-      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
-      this.textBoxScaleFactorsStockNum.ParamName = null;
-      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
-      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorsStockNum.TabIndex = 6;
-      // 
       // labelScaleFactorStockNum
       // 
       this.labelScaleFactorStockNum.AutoSize = true;
@@ -381,16 +304,6 @@
       this.labelScaleFactorStockNum.Size = new System.Drawing.Size(80, 13);
       this.labelScaleFactorStockNum.TabIndex = 5;
       this.labelScaleFactorStockNum.Text = "Stock Numbers";
-      // 
-      // textBoxScaleFactorBiomass
-      // 
-      this.textBoxScaleFactorBiomass.Enabled = false;
-      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(144, 48);
-      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
-      this.textBoxScaleFactorBiomass.ParamName = null;
-      this.textBoxScaleFactorBiomass.PrevValidValue = "";
-      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
-      this.textBoxScaleFactorBiomass.TabIndex = 2;
       // 
       // labelScaleFactorBiomass
       // 
@@ -417,9 +330,9 @@
       // 
       this.groupRetroAdjustment.Controls.Add(this.checkBoxEnableRetroAdjustment);
       this.groupRetroAdjustment.Controls.Add(this.dataGridRetroAdjustment);
-      this.groupRetroAdjustment.Location = new System.Drawing.Point(403, 120);
+      this.groupRetroAdjustment.Location = new System.Drawing.Point(29, 273);
       this.groupRetroAdjustment.Name = "groupRetroAdjustment";
-      this.groupRetroAdjustment.Size = new System.Drawing.Size(352, 266);
+      this.groupRetroAdjustment.Size = new System.Drawing.Size(383, 223);
       this.groupRetroAdjustment.TabIndex = 4;
       this.groupRetroAdjustment.TabStop = false;
       this.groupRetroAdjustment.Text = "Retrospective Adjustment Factors";
@@ -435,6 +348,95 @@
       this.checkBoxEnableRetroAdjustment.UseVisualStyleBackColor = true;
       this.checkBoxEnableRetroAdjustment.CheckedChanged += new System.EventHandler(this.CheckBoxRetroAdjustment_CheckedChanged);
       // 
+      // comboBoxOutputViewerProgram
+      // 
+      this.comboBoxOutputViewerProgram.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+      this.comboBoxOutputViewerProgram.Items.AddRange(new object[] {
+            "System Default",
+            "Notepad",
+            "None"});
+      this.comboBoxOutputViewerProgram.Location = new System.Drawing.Point(18, 32);
+      this.comboBoxOutputViewerProgram.Name = "comboBoxOutputViewerProgram";
+      this.comboBoxOutputViewerProgram.Size = new System.Drawing.Size(339, 21);
+      this.comboBoxOutputViewerProgram.TabIndex = 1;
+      // 
+      // labelOutputViewerProgram
+      // 
+      this.labelOutputViewerProgram.AutoSize = true;
+      this.labelOutputViewerProgram.Location = new System.Drawing.Point(15, 16);
+      this.labelOutputViewerProgram.Name = "labelOutputViewerProgram";
+      this.labelOutputViewerProgram.Size = new System.Drawing.Size(189, 13);
+      this.labelOutputViewerProgram.TabIndex = 0;
+      this.labelOutputViewerProgram.Text = "Program to View AGEPRO Output File ";
+      // 
+      // groupBox_StockSummmaryFlag
+      // 
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButton_SummaryPlusAllAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButton_SummaryNoAux1);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButton_SummaryOnly);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButton_None);
+      this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
+      this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
+      this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(383, 123);
+      this.groupBox_StockSummmaryFlag.TabIndex = 5;
+      this.groupBox_StockSummmaryFlag.TabStop = false;
+      this.groupBox_StockSummmaryFlag.Text = "Stock Summary Ouptut and Auxiliary Data Files";
+      // 
+      // radioButton_None
+      // 
+      this.radioButton_None.AutoSize = true;
+      this.radioButton_None.Location = new System.Drawing.Point(17, 17);
+      this.radioButton_None.Name = "radioButton_None";
+      this.radioButton_None.Size = new System.Drawing.Size(51, 17);
+      this.radioButton_None.TabIndex = 0;
+      this.radioButton_None.TabStop = true;
+      this.radioButton_None.Text = "None";
+      this.radioButton_None.UseVisualStyleBackColor = true;
+      // 
+      // radioButton_SummaryOnly
+      // 
+      this.radioButton_SummaryOnly.AutoSize = true;
+      this.radioButton_SummaryOnly.Location = new System.Drawing.Point(17, 40);
+      this.radioButton_SummaryOnly.Name = "radioButton_SummaryOnly";
+      this.radioButton_SummaryOnly.Size = new System.Drawing.Size(92, 17);
+      this.radioButton_SummaryOnly.TabIndex = 1;
+      this.radioButton_SummaryOnly.TabStop = true;
+      this.radioButton_SummaryOnly.Text = "Summary Only";
+      this.radioButton_SummaryOnly.UseVisualStyleBackColor = true;
+      // 
+      // radioButton_SummaryNoAux1
+      // 
+      this.radioButton_SummaryNoAux1.AutoSize = true;
+      this.radioButton_SummaryNoAux1.Location = new System.Drawing.Point(17, 63);
+      this.radioButton_SummaryNoAux1.Name = "radioButton_SummaryNoAux1";
+      this.radioButton_SummaryNoAux1.Size = new System.Drawing.Size(292, 17);
+      this.radioButton_SummaryNoAux1.TabIndex = 2;
+      this.radioButton_SummaryNoAux1.TabStop = true;
+      this.radioButton_SummaryNoAux1.Text = "Summary Plus Auxiliary Files EXCLUDING Stock Aux File";
+      this.radioButton_SummaryNoAux1.UseVisualStyleBackColor = true;
+      // 
+      // radioButton_SummaryPlusAllAux
+      // 
+      this.radioButton_SummaryPlusAllAux.AutoSize = true;
+      this.radioButton_SummaryPlusAllAux.Location = new System.Drawing.Point(17, 86);
+      this.radioButton_SummaryPlusAllAux.Name = "radioButton_SummaryPlusAllAux";
+      this.radioButton_SummaryPlusAllAux.Size = new System.Drawing.Size(170, 17);
+      this.radioButton_SummaryPlusAllAux.TabIndex = 3;
+      this.radioButton_SummaryPlusAllAux.TabStop = true;
+      this.radioButton_SummaryPlusAllAux.Text = "Summary Plus All Auxiliary Files";
+      this.radioButton_SummaryPlusAllAux.UseVisualStyleBackColor = true;
+      // 
+      // groupOutputViewer
+      // 
+      this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
+      this.groupOutputViewer.Controls.Add(this.labelOutputViewerProgram);
+      this.groupOutputViewer.Location = new System.Drawing.Point(418, 15);
+      this.groupOutputViewer.Name = "groupOutputViewer";
+      this.groupOutputViewer.Size = new System.Drawing.Size(390, 65);
+      this.groupOutputViewer.TabIndex = 6;
+      this.groupOutputViewer.TabStop = false;
+      this.groupOutputViewer.Text = "Output File Viewer";
+      // 
       // dataGridRetroAdjustment
       // 
       this.dataGridRetroAdjustment.AllowUserToAddRows = false;
@@ -447,51 +449,113 @@
       this.dataGridRetroAdjustment.Name = "dataGridRetroAdjustment";
       this.dataGridRetroAdjustment.nftReadOnly = false;
       this.dataGridRetroAdjustment.RowHeadersWidth = 75;
-      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(329, 220);
+      this.dataGridRetroAdjustment.Size = new System.Drawing.Size(356, 171);
       this.dataGridRetroAdjustment.TabIndex = 0;
       this.dataGridRetroAdjustment.CellFormatting += new System.Windows.Forms.DataGridViewCellFormattingEventHandler(this.DataGridRetroAdjustment_CellFormatting);
       // 
-      // groupOutputViewer
+      // textBoxScaleFactorRecruits
       // 
-      this.groupOutputViewer.Controls.Add(this.comboBoxOutputViewerProgram);
-      this.groupOutputViewer.Controls.Add(this.labelOutputViewerProgram);
-      this.groupOutputViewer.Location = new System.Drawing.Point(403, 392);
-      this.groupOutputViewer.Name = "groupOutputViewer";
-      this.groupOutputViewer.Size = new System.Drawing.Size(352, 75);
-      this.groupOutputViewer.TabIndex = 5;
-      this.groupOutputViewer.TabStop = false;
-      this.groupOutputViewer.Text = "Output File Viewer";
+      this.textBoxScaleFactorRecruits.Enabled = false;
+      this.textBoxScaleFactorRecruits.Location = new System.Drawing.Point(144, 74);
+      this.textBoxScaleFactorRecruits.Name = "textBoxScaleFactorRecruits";
+      this.textBoxScaleFactorRecruits.ParamName = null;
+      this.textBoxScaleFactorRecruits.PrevValidValue = "";
+      this.textBoxScaleFactorRecruits.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorRecruits.TabIndex = 4;
       // 
-      // comboBoxOutputViewerProgram
+      // textBoxScaleFactorsStockNum
       // 
-      this.comboBoxOutputViewerProgram.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-      this.comboBoxOutputViewerProgram.Items.AddRange(new object[] {
-            "System Default",
-            "Notepad",
-            "None"});
-      this.comboBoxOutputViewerProgram.Location = new System.Drawing.Point(17, 39);
-      this.comboBoxOutputViewerProgram.Name = "comboBoxOutputViewerProgram";
-      this.comboBoxOutputViewerProgram.Size = new System.Drawing.Size(318, 21);
-      this.comboBoxOutputViewerProgram.TabIndex = 1;
+      this.textBoxScaleFactorsStockNum.Enabled = false;
+      this.textBoxScaleFactorsStockNum.Location = new System.Drawing.Point(144, 100);
+      this.textBoxScaleFactorsStockNum.Name = "textBoxScaleFactorsStockNum";
+      this.textBoxScaleFactorsStockNum.ParamName = null;
+      this.textBoxScaleFactorsStockNum.PrevValidValue = "";
+      this.textBoxScaleFactorsStockNum.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorsStockNum.TabIndex = 6;
       // 
-      // labelOutputViewerProgram
+      // textBoxScaleFactorBiomass
       // 
-      this.labelOutputViewerProgram.AutoSize = true;
-      this.labelOutputViewerProgram.Location = new System.Drawing.Point(14, 23);
-      this.labelOutputViewerProgram.Name = "labelOutputViewerProgram";
-      this.labelOutputViewerProgram.Size = new System.Drawing.Size(189, 13);
-      this.labelOutputViewerProgram.TabIndex = 0;
-      this.labelOutputViewerProgram.Text = "Program to View AGEPRO Output File ";
+      this.textBoxScaleFactorBiomass.Enabled = false;
+      this.textBoxScaleFactorBiomass.Location = new System.Drawing.Point(144, 48);
+      this.textBoxScaleFactorBiomass.Name = "textBoxScaleFactorBiomass";
+      this.textBoxScaleFactorBiomass.ParamName = null;
+      this.textBoxScaleFactorBiomass.PrevValidValue = "";
+      this.textBoxScaleFactorBiomass.Size = new System.Drawing.Size(100, 20);
+      this.textBoxScaleFactorBiomass.TabIndex = 2;
+      // 
+      // textBoxBoundsNatMortality
+      // 
+      this.textBoxBoundsNatMortality.Enabled = false;
+      this.textBoxBoundsNatMortality.Location = new System.Drawing.Point(158, 68);
+      this.textBoxBoundsNatMortality.Name = "textBoxBoundsNatMortality";
+      this.textBoxBoundsNatMortality.ParamName = null;
+      this.textBoxBoundsNatMortality.PrevValidValue = "";
+      this.textBoxBoundsNatMortality.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsNatMortality.TabIndex = 4;
+      this.textBoxBoundsNatMortality.Text = "1.0";
+      // 
+      // textBoxBoundsMaxWeight
+      // 
+      this.textBoxBoundsMaxWeight.Enabled = false;
+      this.textBoxBoundsMaxWeight.Location = new System.Drawing.Point(158, 42);
+      this.textBoxBoundsMaxWeight.Name = "textBoxBoundsMaxWeight";
+      this.textBoxBoundsMaxWeight.ParamName = null;
+      this.textBoxBoundsMaxWeight.PrevValidValue = "";
+      this.textBoxBoundsMaxWeight.Size = new System.Drawing.Size(100, 20);
+      this.textBoxBoundsMaxWeight.TabIndex = 2;
+      this.textBoxBoundsMaxWeight.Text = "10.0";
+      // 
+      // textBoxRefFishMortality
+      // 
+      this.textBoxRefFishMortality.Enabled = false;
+      this.textBoxRefFishMortality.Location = new System.Drawing.Point(189, 120);
+      this.textBoxRefFishMortality.Name = "textBoxRefFishMortality";
+      this.textBoxRefFishMortality.ParamName = null;
+      this.textBoxRefFishMortality.PrevValidValue = "";
+      this.textBoxRefFishMortality.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefFishMortality.TabIndex = 8;
+      // 
+      // textBoxRefMeanBiomass
+      // 
+      this.textBoxRefMeanBiomass.Enabled = false;
+      this.textBoxRefMeanBiomass.Location = new System.Drawing.Point(189, 94);
+      this.textBoxRefMeanBiomass.Name = "textBoxRefMeanBiomass";
+      this.textBoxRefMeanBiomass.ParamName = null;
+      this.textBoxRefMeanBiomass.PrevValidValue = "";
+      this.textBoxRefMeanBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefMeanBiomass.TabIndex = 6;
+      // 
+      // textBoxRefJan1Biomass
+      // 
+      this.textBoxRefJan1Biomass.Enabled = false;
+      this.textBoxRefJan1Biomass.Location = new System.Drawing.Point(189, 68);
+      this.textBoxRefJan1Biomass.Name = "textBoxRefJan1Biomass";
+      this.textBoxRefJan1Biomass.ParamName = null;
+      this.textBoxRefJan1Biomass.PrevValidValue = "";
+      this.textBoxRefJan1Biomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefJan1Biomass.TabIndex = 4;
+      // 
+      // textBoxRefSpawnBiomass
+      // 
+      this.textBoxRefSpawnBiomass.Enabled = false;
+      this.textBoxRefSpawnBiomass.Location = new System.Drawing.Point(189, 42);
+      this.textBoxRefSpawnBiomass.Name = "textBoxRefSpawnBiomass";
+      this.textBoxRefSpawnBiomass.ParamName = null;
+      this.textBoxRefSpawnBiomass.PrevValidValue = "";
+      this.textBoxRefSpawnBiomass.Size = new System.Drawing.Size(117, 20);
+      this.textBoxRefSpawnBiomass.TabIndex = 2;
       // 
       // ControlMiscOptions
       // 
       this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
       this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
       this.Controls.Add(this.groupOutputViewer);
+      this.Controls.Add(this.groupBox_StockSummmaryFlag);
       this.Controls.Add(this.groupRetroAdjustment);
       this.Controls.Add(this.groupScaleFactors);
       this.Controls.Add(this.groupBounds);
       this.Controls.Add(this.groupRefpoints);
+      this.Controls.Add(this.checkBoxEnableSummaryReport);
       this.Controls.Add(this.groupOuputOptions);
       this.Name = "ControlMiscOptions";
       this.Size = new System.Drawing.Size(900, 520);
@@ -506,10 +570,13 @@
       this.groupScaleFactors.PerformLayout();
       this.groupRetroAdjustment.ResumeLayout(false);
       this.groupRetroAdjustment.PerformLayout();
-      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
+      this.groupBox_StockSummmaryFlag.ResumeLayout(false);
+      this.groupBox_StockSummmaryFlag.PerformLayout();
       this.groupOutputViewer.ResumeLayout(false);
       this.groupOutputViewer.PerformLayout();
+      ((System.ComponentModel.ISupportInitialize)(this.dataGridRetroAdjustment)).EndInit();
       this.ResumeLayout(false);
+      this.PerformLayout();
 
         }
 
@@ -549,8 +616,13 @@
         private System.Windows.Forms.CheckBox checkBoxEnableRetroAdjustment;
         private Nmfs.Agepro.Gui.NftDataGridView dataGridRetroAdjustment;
         private System.Windows.Forms.NumericUpDown spinBoxReportPercentile;
-        private System.Windows.Forms.GroupBox groupOutputViewer;
         private System.Windows.Forms.ComboBox comboBoxOutputViewerProgram;
         private System.Windows.Forms.Label labelOutputViewerProgram;
-    }
+    private System.Windows.Forms.GroupBox groupBox_StockSummmaryFlag;
+    private System.Windows.Forms.RadioButton radioButton_None;
+    private System.Windows.Forms.RadioButton radioButton_SummaryNoAux1;
+    private System.Windows.Forms.RadioButton radioButton_SummaryOnly;
+    private System.Windows.Forms.RadioButton radioButton_SummaryPlusAllAux;
+    private System.Windows.Forms.GroupBox groupOutputViewer;
+  }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -55,10 +55,10 @@
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
       this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
-      this.radioButtonSummaryPlusAllAux = new System.Windows.Forms.RadioButton();
-      this.radioButtonSummaryNoAux1 = new System.Windows.Forms.RadioButton();
-      this.radioButtonSummaryOnly = new System.Windows.Forms.RadioButton();
-      this.radioButtonNone = new System.Windows.Forms.RadioButton();
+      this.radioButtonStockDistExceptAuxStockVector = new System.Windows.Forms.RadioButton();
+      this.radioButtonSummaryStockDistNoAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonStockDistAllAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonNoStockDistAllAux = new System.Windows.Forms.RadioButton();
       this.groupOutputViewer = new System.Windows.Forms.GroupBox();
       this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
       this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
@@ -372,64 +372,64 @@
       // 
       // groupBox_StockSummmaryFlag
       // 
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonSummaryPlusAllAux);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonSummaryNoAux1);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonSummaryOnly);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNone);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockDistExceptAuxStockVector);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonSummaryStockDistNoAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonStockDistAllAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNoStockDistAllAux);
       this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
       this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
       this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(383, 123);
       this.groupBox_StockSummmaryFlag.TabIndex = 0;
       this.groupBox_StockSummmaryFlag.TabStop = false;
-      this.groupBox_StockSummmaryFlag.Text = "Stock Summary Ouptut and Auxiliary Data Files";
+      this.groupBox_StockSummmaryFlag.Text = "Stock Distribution Summary and Auxiliary Data Files";
       // 
-      // radioButtonSummaryPlusAllAux
+      // radioButtonStockDistExceptAuxStockVector
       // 
-      this.radioButtonSummaryPlusAllAux.AutoSize = true;
-      this.radioButtonSummaryPlusAllAux.Location = new System.Drawing.Point(17, 86);
-      this.radioButtonSummaryPlusAllAux.Name = "radioButtonSummaryPlusAllAux";
-      this.radioButtonSummaryPlusAllAux.Size = new System.Drawing.Size(170, 17);
-      this.radioButtonSummaryPlusAllAux.TabIndex = 3;
-      this.radioButtonSummaryPlusAllAux.TabStop = true;
-      this.radioButtonSummaryPlusAllAux.Text = "Summary Plus All Auxiliary Files";
-      this.radioButtonSummaryPlusAllAux.UseVisualStyleBackColor = true;
-      this.radioButtonSummaryPlusAllAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
+      this.radioButtonStockDistExceptAuxStockVector.AutoSize = true;
+      this.radioButtonStockDistExceptAuxStockVector.Location = new System.Drawing.Point(17, 86);
+      this.radioButtonStockDistExceptAuxStockVector.Name = "radioButtonStockDistExceptAuxStockVector";
+      this.radioButtonStockDistExceptAuxStockVector.Size = new System.Drawing.Size(330, 17);
+      this.radioButtonStockDistExceptAuxStockVector.TabIndex = 3;
+      this.radioButtonStockDistExceptAuxStockVector.TabStop = true;
+      this.radioButtonStockDistExceptAuxStockVector.Text = "Stock Distribution and Auxiliary Files EXCEPT Auxiliary Stock File";
+      this.radioButtonStockDistExceptAuxStockVector.UseVisualStyleBackColor = true;
+      this.radioButtonStockDistExceptAuxStockVector.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryPlusAllAux_CheckedChanged);
       // 
-      // radioButtonSummaryNoAux1
+      // radioButtonSummaryStockDistNoAux
       // 
-      this.radioButtonSummaryNoAux1.AutoSize = true;
-      this.radioButtonSummaryNoAux1.Location = new System.Drawing.Point(17, 63);
-      this.radioButtonSummaryNoAux1.Name = "radioButtonSummaryNoAux1";
-      this.radioButtonSummaryNoAux1.Size = new System.Drawing.Size(292, 17);
-      this.radioButtonSummaryNoAux1.TabIndex = 2;
-      this.radioButtonSummaryNoAux1.TabStop = true;
-      this.radioButtonSummaryNoAux1.Text = "Summary Plus Auxiliary Files EXCLUDING Stock Aux File";
-      this.radioButtonSummaryNoAux1.UseVisualStyleBackColor = true;
-      this.radioButtonSummaryNoAux1.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryNoAux1_CheckedChanged);
+      this.radioButtonSummaryStockDistNoAux.AutoSize = true;
+      this.radioButtonSummaryStockDistNoAux.Location = new System.Drawing.Point(17, 63);
+      this.radioButtonSummaryStockDistNoAux.Name = "radioButtonSummaryStockDistNoAux";
+      this.radioButtonSummaryStockDistNoAux.Size = new System.Drawing.Size(220, 17);
+      this.radioButtonSummaryStockDistNoAux.TabIndex = 2;
+      this.radioButtonSummaryStockDistNoAux.TabStop = true;
+      this.radioButtonSummaryStockDistNoAux.Text = "Stock Distribution Only (No Auxiliary Files)";
+      this.radioButtonSummaryStockDistNoAux.UseVisualStyleBackColor = true;
+      this.radioButtonSummaryStockDistNoAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryNoAux1_CheckedChanged);
       // 
-      // radioButtonSummaryOnly
+      // radioButtonStockDistAllAux
       // 
-      this.radioButtonSummaryOnly.AutoSize = true;
-      this.radioButtonSummaryOnly.Location = new System.Drawing.Point(17, 40);
-      this.radioButtonSummaryOnly.Name = "radioButtonSummaryOnly";
-      this.radioButtonSummaryOnly.Size = new System.Drawing.Size(92, 17);
-      this.radioButtonSummaryOnly.TabIndex = 1;
-      this.radioButtonSummaryOnly.TabStop = true;
-      this.radioButtonSummaryOnly.Text = "Summary Only";
-      this.radioButtonSummaryOnly.UseVisualStyleBackColor = true;
-      this.radioButtonSummaryOnly.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryOnly_CheckedChanged);
+      this.radioButtonStockDistAllAux.AutoSize = true;
+      this.radioButtonStockDistAllAux.Location = new System.Drawing.Point(17, 40);
+      this.radioButtonStockDistAllAux.Name = "radioButtonStockDistAllAux";
+      this.radioButtonStockDistAllAux.Size = new System.Drawing.Size(197, 17);
+      this.radioButtonStockDistAllAux.TabIndex = 1;
+      this.radioButtonStockDistAllAux.TabStop = true;
+      this.radioButtonStockDistAllAux.Text = "Auxiliary Files and Stock Distribution ";
+      this.radioButtonStockDistAllAux.UseVisualStyleBackColor = true;
+      this.radioButtonStockDistAllAux.CheckedChanged += new System.EventHandler(this.RadioButtonSummaryOnly_CheckedChanged);
       // 
-      // radioButtonNone
+      // radioButtonNoStockDistAllAux
       // 
-      this.radioButtonNone.AutoSize = true;
-      this.radioButtonNone.Location = new System.Drawing.Point(17, 17);
-      this.radioButtonNone.Name = "radioButtonNone";
-      this.radioButtonNone.Size = new System.Drawing.Size(51, 17);
-      this.radioButtonNone.TabIndex = 0;
-      this.radioButtonNone.TabStop = true;
-      this.radioButtonNone.Text = "None";
-      this.radioButtonNone.UseVisualStyleBackColor = true;
-      this.radioButtonNone.CheckedChanged += new System.EventHandler(this.RadioButtonNone_CheckedChanged);
+      this.radioButtonNoStockDistAllAux.AutoSize = true;
+      this.radioButtonNoStockDistAllAux.Location = new System.Drawing.Point(17, 17);
+      this.radioButtonNoStockDistAllAux.Name = "radioButtonNoStockDistAllAux";
+      this.radioButtonNoStockDistAllAux.Size = new System.Drawing.Size(220, 17);
+      this.radioButtonNoStockDistAllAux.TabIndex = 0;
+      this.radioButtonNoStockDistAllAux.TabStop = true;
+      this.radioButtonNoStockDistAllAux.Text = "Auxiliary Files Only (No Stock Distribution)";
+      this.radioButtonNoStockDistAllAux.UseVisualStyleBackColor = true;
+      this.radioButtonNoStockDistAllAux.CheckedChanged += new System.EventHandler(this.RadioButtonNone_CheckedChanged);
       // 
       // groupOutputViewer
       // 
@@ -624,10 +624,10 @@
         private System.Windows.Forms.ComboBox comboBoxOutputViewerProgram;
         private System.Windows.Forms.Label labelOutputViewerProgram;
     private System.Windows.Forms.GroupBox groupBox_StockSummmaryFlag;
-    private System.Windows.Forms.RadioButton radioButtonNone;
-    private System.Windows.Forms.RadioButton radioButtonSummaryNoAux1;
-    private System.Windows.Forms.RadioButton radioButtonSummaryOnly;
-    private System.Windows.Forms.RadioButton radioButtonSummaryPlusAllAux;
+    private System.Windows.Forms.RadioButton radioButtonNoStockDistAllAux;
+    private System.Windows.Forms.RadioButton radioButtonSummaryStockDistNoAux;
+    private System.Windows.Forms.RadioButton radioButtonStockDistAllAux;
+    private System.Windows.Forms.RadioButton radioButtonStockDistExceptAuxStockVector;
     private System.Windows.Forms.GroupBox groupOutputViewer;
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.Designer.cs
@@ -55,10 +55,10 @@
       this.comboBoxOutputViewerProgram = new System.Windows.Forms.ComboBox();
       this.labelOutputViewerProgram = new System.Windows.Forms.Label();
       this.groupBox_StockSummmaryFlag = new System.Windows.Forms.GroupBox();
-      this.radioButton_SummaryPlusAllAux = new System.Windows.Forms.RadioButton();
-      this.radioButton_SummaryNoAux1 = new System.Windows.Forms.RadioButton();
-      this.radioButton_SummaryOnly = new System.Windows.Forms.RadioButton();
-      this.radioButton_None = new System.Windows.Forms.RadioButton();
+      this.radioButtonSummaryPlusAllAux = new System.Windows.Forms.RadioButton();
+      this.radioButtonSummaryNoAux1 = new System.Windows.Forms.RadioButton();
+      this.radioButtonSummaryOnly = new System.Windows.Forms.RadioButton();
+      this.radioButtonNone = new System.Windows.Forms.RadioButton();
       this.groupOutputViewer = new System.Windows.Forms.GroupBox();
       this.dataGridRetroAdjustment = new Nmfs.Agepro.Gui.NftDataGridView();
       this.textBoxScaleFactorRecruits = new Nmfs.Agepro.Gui.NftTextBox();
@@ -371,10 +371,10 @@
       // 
       // groupBox_StockSummmaryFlag
       // 
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButton_SummaryPlusAllAux);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButton_SummaryNoAux1);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButton_SummaryOnly);
-      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButton_None);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonSummaryPlusAllAux);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonSummaryNoAux1);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonSummaryOnly);
+      this.groupBox_StockSummmaryFlag.Controls.Add(this.radioButtonNone);
       this.groupBox_StockSummmaryFlag.Location = new System.Drawing.Point(29, 15);
       this.groupBox_StockSummmaryFlag.Name = "groupBox_StockSummmaryFlag";
       this.groupBox_StockSummmaryFlag.Size = new System.Drawing.Size(383, 123);
@@ -382,49 +382,49 @@
       this.groupBox_StockSummmaryFlag.TabStop = false;
       this.groupBox_StockSummmaryFlag.Text = "Stock Summary Ouptut and Auxiliary Data Files";
       // 
-      // radioButton_SummaryPlusAllAux
+      // radioButtonSummaryPlusAllAux
       // 
-      this.radioButton_SummaryPlusAllAux.AutoSize = true;
-      this.radioButton_SummaryPlusAllAux.Location = new System.Drawing.Point(17, 86);
-      this.radioButton_SummaryPlusAllAux.Name = "radioButton_SummaryPlusAllAux";
-      this.radioButton_SummaryPlusAllAux.Size = new System.Drawing.Size(170, 17);
-      this.radioButton_SummaryPlusAllAux.TabIndex = 3;
-      this.radioButton_SummaryPlusAllAux.TabStop = true;
-      this.radioButton_SummaryPlusAllAux.Text = "Summary Plus All Auxiliary Files";
-      this.radioButton_SummaryPlusAllAux.UseVisualStyleBackColor = true;
+      this.radioButtonSummaryPlusAllAux.AutoSize = true;
+      this.radioButtonSummaryPlusAllAux.Location = new System.Drawing.Point(17, 86);
+      this.radioButtonSummaryPlusAllAux.Name = "radioButtonSummaryPlusAllAux";
+      this.radioButtonSummaryPlusAllAux.Size = new System.Drawing.Size(170, 17);
+      this.radioButtonSummaryPlusAllAux.TabIndex = 3;
+      this.radioButtonSummaryPlusAllAux.TabStop = true;
+      this.radioButtonSummaryPlusAllAux.Text = "Summary Plus All Auxiliary Files";
+      this.radioButtonSummaryPlusAllAux.UseVisualStyleBackColor = true;
       // 
-      // radioButton_SummaryNoAux1
+      // radioButtonSummaryNoAux1
       // 
-      this.radioButton_SummaryNoAux1.AutoSize = true;
-      this.radioButton_SummaryNoAux1.Location = new System.Drawing.Point(17, 63);
-      this.radioButton_SummaryNoAux1.Name = "radioButton_SummaryNoAux1";
-      this.radioButton_SummaryNoAux1.Size = new System.Drawing.Size(292, 17);
-      this.radioButton_SummaryNoAux1.TabIndex = 2;
-      this.radioButton_SummaryNoAux1.TabStop = true;
-      this.radioButton_SummaryNoAux1.Text = "Summary Plus Auxiliary Files EXCLUDING Stock Aux File";
-      this.radioButton_SummaryNoAux1.UseVisualStyleBackColor = true;
+      this.radioButtonSummaryNoAux1.AutoSize = true;
+      this.radioButtonSummaryNoAux1.Location = new System.Drawing.Point(17, 63);
+      this.radioButtonSummaryNoAux1.Name = "radioButtonSummaryNoAux1";
+      this.radioButtonSummaryNoAux1.Size = new System.Drawing.Size(292, 17);
+      this.radioButtonSummaryNoAux1.TabIndex = 2;
+      this.radioButtonSummaryNoAux1.TabStop = true;
+      this.radioButtonSummaryNoAux1.Text = "Summary Plus Auxiliary Files EXCLUDING Stock Aux File";
+      this.radioButtonSummaryNoAux1.UseVisualStyleBackColor = true;
       // 
-      // radioButton_SummaryOnly
+      // radioButtonSummaryOnly
       // 
-      this.radioButton_SummaryOnly.AutoSize = true;
-      this.radioButton_SummaryOnly.Location = new System.Drawing.Point(17, 40);
-      this.radioButton_SummaryOnly.Name = "radioButton_SummaryOnly";
-      this.radioButton_SummaryOnly.Size = new System.Drawing.Size(92, 17);
-      this.radioButton_SummaryOnly.TabIndex = 1;
-      this.radioButton_SummaryOnly.TabStop = true;
-      this.radioButton_SummaryOnly.Text = "Summary Only";
-      this.radioButton_SummaryOnly.UseVisualStyleBackColor = true;
+      this.radioButtonSummaryOnly.AutoSize = true;
+      this.radioButtonSummaryOnly.Location = new System.Drawing.Point(17, 40);
+      this.radioButtonSummaryOnly.Name = "radioButtonSummaryOnly";
+      this.radioButtonSummaryOnly.Size = new System.Drawing.Size(92, 17);
+      this.radioButtonSummaryOnly.TabIndex = 1;
+      this.radioButtonSummaryOnly.TabStop = true;
+      this.radioButtonSummaryOnly.Text = "Summary Only";
+      this.radioButtonSummaryOnly.UseVisualStyleBackColor = true;
       // 
-      // radioButton_None
+      // radioButtonNone
       // 
-      this.radioButton_None.AutoSize = true;
-      this.radioButton_None.Location = new System.Drawing.Point(17, 17);
-      this.radioButton_None.Name = "radioButton_None";
-      this.radioButton_None.Size = new System.Drawing.Size(51, 17);
-      this.radioButton_None.TabIndex = 0;
-      this.radioButton_None.TabStop = true;
-      this.radioButton_None.Text = "None";
-      this.radioButton_None.UseVisualStyleBackColor = true;
+      this.radioButtonNone.AutoSize = true;
+      this.radioButtonNone.Location = new System.Drawing.Point(17, 17);
+      this.radioButtonNone.Name = "radioButtonNone";
+      this.radioButtonNone.Size = new System.Drawing.Size(51, 17);
+      this.radioButtonNone.TabIndex = 0;
+      this.radioButtonNone.TabStop = true;
+      this.radioButtonNone.Text = "None";
+      this.radioButtonNone.UseVisualStyleBackColor = true;
       // 
       // groupOutputViewer
       // 
@@ -619,10 +619,10 @@
         private System.Windows.Forms.ComboBox comboBoxOutputViewerProgram;
         private System.Windows.Forms.Label labelOutputViewerProgram;
     private System.Windows.Forms.GroupBox groupBox_StockSummmaryFlag;
-    private System.Windows.Forms.RadioButton radioButton_None;
-    private System.Windows.Forms.RadioButton radioButton_SummaryNoAux1;
-    private System.Windows.Forms.RadioButton radioButton_SummaryOnly;
-    private System.Windows.Forms.RadioButton radioButton_SummaryPlusAllAux;
+    private System.Windows.Forms.RadioButton radioButtonNone;
+    private System.Windows.Forms.RadioButton radioButtonSummaryNoAux1;
+    private System.Windows.Forms.RadioButton radioButtonSummaryOnly;
+    private System.Windows.Forms.RadioButton radioButtonSummaryPlusAllAux;
     private System.Windows.Forms.GroupBox groupOutputViewer;
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -343,39 +343,49 @@ namespace Nmfs.Agepro.Gui
         throw new ArgumentNullException(nameof(inputFile));
       }
 
-      this.MiscOptionsEnableSummaryReport = inputFile.Options.EnableSummaryReport;
+      miscOptionsNAges = inputFile.General.NumAges();
+      miscOptionsFirstAge = inputFile.General.AgeBegin;
+
+      // Options (w/ OutputSummaryFlag)
+      MiscOptionsEnableSummaryReport = inputFile.Options.EnableSummaryReport; 
+      SummaryAuxFileOutputFlag = (StockSummaryFlag)inputFile.Options.OutputSummaryReport;
       
-      this.MiscOptionsEnableAuxStochasticFiles = inputFile.Options.EnableAuxStochasticFiles;
-      this.SummaryAuxFileOutputFlag = (StockSummaryFlag)inputFile.Options.OutputSummaryReport;
-      this.MiscOptionsEnableExportR = inputFile.Options.EnableExportR;
-      this.MiscOptionsEnablePercentileReport = inputFile.Options.EnablePercentileReport;
-      this.MiscOptionsReportPercentile = Convert.ToDouble(inputFile.ReportPercentile.Percentile);
+      MiscOptionsEnableAuxStochasticFiles = inputFile.Options.EnableAuxStochasticFiles;
+      MiscOptionsEnableExportR = inputFile.Options.EnableExportR;
 
-      this.MiscOptionsEnableRefpointsReport = inputFile.Options.EnableRefpoint;
-      this.MiscOptionsRefSpawnBiomass = inputFile.Refpoint.RefSpawnBio.ToString();
-      this.MiscOptionsRefJan1Biomass = inputFile.Refpoint.RefJan1Bio.ToString();
-      this.MiscOptionsRefMeanBiomass = inputFile.Refpoint.RefMeanBio.ToString();
-      this.MiscOptionsRefFishingMortality = inputFile.Refpoint.RefFMort.ToString();
+      // Percentile Report
+      MiscOptionsEnablePercentileReport = inputFile.Options.EnablePercentileReport;
+      MiscOptionsReportPercentile = Convert.ToDouble(inputFile.ReportPercentile.Percentile);
 
-      this.MiscOptionsEnableScaleFactors = inputFile.Options.EnableScaleFactors;
-      this.MiscOptionsScaleFactorBiomass = inputFile.Scale.ScaleBio.ToString();
-      this.MiscOptionsScaleFactorRecruits = inputFile.Scale.ScaleRec.ToString();
-      this.MiscOptionsScaleFactorStockNumbers = inputFile.Scale.ScaleStockNum.ToString();
+      // Biological Reference Points
+      MiscOptionsEnableRefpointsReport = inputFile.Options.EnableRefpoint;
+      MiscOptionsRefSpawnBiomass = inputFile.Refpoint.RefSpawnBio.ToString();
+      MiscOptionsRefJan1Biomass = inputFile.Refpoint.RefJan1Bio.ToString();
+      MiscOptionsRefMeanBiomass = inputFile.Refpoint.RefMeanBio.ToString();
+      MiscOptionsRefFishingMortality = inputFile.Refpoint.RefFMort.ToString();
 
-      this.MiscOptionsBounds = inputFile.Options.EnableBounds;
-      this.MiscOptionsBoundsMaxWeight = inputFile.Bounds.MaxWeight.ToString();
-      this.MiscOptionsBoundsNaturalMortality = inputFile.Bounds.MaxNatMort.ToString();
+      // Scale Factors
+      MiscOptionsEnableScaleFactors = inputFile.Options.EnableScaleFactors;
+      MiscOptionsScaleFactorBiomass = inputFile.Scale.ScaleBio.ToString();
+      MiscOptionsScaleFactorRecruits = inputFile.Scale.ScaleRec.ToString();
+      MiscOptionsScaleFactorStockNumbers = inputFile.Scale.ScaleStockNum.ToString();
 
-      this.MiscOptionsEnableRetroAdjustmentFactors = inputFile.Options.EnableRetroAdjustmentFactors;
-      this.miscOptionsNAges = inputFile.General.NumAges();
-      this.miscOptionsFirstAge = inputFile.General.AgeBegin;
+      // Max Bounds
+      MiscOptionsBounds = inputFile.Options.EnableBounds;
+      MiscOptionsBoundsMaxWeight = inputFile.Bounds.MaxWeight.ToString();
+      MiscOptionsBoundsNaturalMortality = inputFile.Bounds.MaxNatMort.ToString();
 
-      this.LoadRetroAdjustmentsFactorTable(inputFile);
-
-      if (this.MiscOptionsEnableRetroAdjustmentFactors)
+      // Retro Adjustment Factors 
+      MiscOptionsEnableRetroAdjustmentFactors = inputFile.Options.EnableRetroAdjustmentFactors;
+      LoadRetroAdjustmentsFactorTable(inputFile);
+      
+      if (MiscOptionsEnableRetroAdjustmentFactors)
       {
-        this.SetRetroAdjustmentFactorRowHeaders();
+        SetRetroAdjustmentFactorRowHeaders();
       }
+
+      //OuputSummaryFlag Radio Buttons
+      SetupSummaryStockFlagRadioButtons(inputFile.Options);
     }
 
     #endregion

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -18,21 +18,26 @@ namespace Nmfs.Agepro.Gui
     public ControlMiscOptions()
     {
       InitializeComponent();
+
+      //AGEPRO Ouptput Viewer Program
       comboBoxOutputViewerProgram.SelectedIndex = 0;
 
       //Set Bounds defaults
       MiscOptionsBoundsMaxWeight = "10.0";
       MiscOptionsBoundsNaturalMortality = "1.0";
 
+      //Refpoints
       MiscOptionsRefJan1Biomass = "0.0";
       MiscOptionsRefMeanBiomass = "0.0";
       MiscOptionsRefSpawnBiomass = "0.0";
       MiscOptionsRefFishingMortality = "0.0";
 
+      //Scale Factors
       MiscOptionsScaleFactorBiomass = "0.0";
       MiscOptionsScaleFactorRecruits = "0.0";
       MiscOptionsScaleFactorStockNumbers = "0.0";
 
+      //Report Percentile
       MiscOptionsReportPercentile = 0;
     }
 

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -203,10 +203,10 @@ namespace Nmfs.Agepro.Gui
     /// <param name="miscOpt">Refrerence Points Option Object</param>
     public void SetupRefpointDataBindings(CoreLib.Refpoint miscOpt)
     {
-      SetControlDataBindings(textBoxRefSpawnBiomass, miscOpt, nameof(CoreLib.Refpoint.RefSpawnBio)); // "RefSpawnBio"
-      SetControlDataBindings(textBoxRefJan1Biomass, miscOpt, nameof(CoreLib.Refpoint.RefJan1Bio)); // "RefJan1Bio"
-      SetControlDataBindings(textBoxRefMeanBiomass, miscOpt, nameof(CoreLib.Refpoint.RefMeanBio)); // "RefMeanBio"
-      SetControlDataBindings(textBoxRefFishMortality, miscOpt, nameof(CoreLib.Refpoint.RefFMort)); // "RefFMort"
+      SetupTextBoxDataBindings(textBoxRefSpawnBiomass, miscOpt, nameof(CoreLib.Refpoint.RefSpawnBio)); // "RefSpawnBio"
+      SetupTextBoxDataBindings(textBoxRefJan1Biomass, miscOpt, nameof(CoreLib.Refpoint.RefJan1Bio)); // "RefJan1Bio"
+      SetupTextBoxDataBindings(textBoxRefMeanBiomass, miscOpt, nameof(CoreLib.Refpoint.RefMeanBio)); // "RefMeanBio"
+      SetupTextBoxDataBindings(textBoxRefFishMortality, miscOpt, nameof(CoreLib.Refpoint.RefFMort)); // "RefFMort"
     }
 
     /// <summary>
@@ -215,9 +215,9 @@ namespace Nmfs.Agepro.Gui
     /// <param name="miscOpt">AGEPRO CoreLib Misc Options Object</param>
     public void SetupScaleFactorsDataBindings(CoreLib.ScaleFactors miscOpt)
     {
-      SetControlDataBindings(textBoxScaleFactorBiomass, miscOpt, nameof(CoreLib.ScaleFactors.ScaleBio)); // "ScaleBio"
-      SetControlDataBindings(textBoxScaleFactorRecruits, miscOpt, nameof(CoreLib.ScaleFactors.ScaleRec)); // "ScaleRec"
-      SetControlDataBindings(textBoxScaleFactorsStockNum, miscOpt, nameof(CoreLib.ScaleFactors.ScaleStockNum)); // "ScaleStockNum"
+      SetupTextBoxDataBindings(textBoxScaleFactorBiomass, miscOpt, nameof(CoreLib.ScaleFactors.ScaleBio)); // "ScaleBio"
+      SetupTextBoxDataBindings(textBoxScaleFactorRecruits, miscOpt, nameof(CoreLib.ScaleFactors.ScaleRec)); // "ScaleRec"
+      SetupTextBoxDataBindings(textBoxScaleFactorsStockNum, miscOpt, nameof(CoreLib.ScaleFactors.ScaleStockNum)); // "ScaleStockNum"
     }
 
     /// <summary>
@@ -226,8 +226,8 @@ namespace Nmfs.Agepro.Gui
     /// <param name="miscOpt">AGEPRO CoreLib Misc Options Object</param>
     public void SetupBoundsDataBindings(CoreLib.Bounds miscOpt)
     {
-      SetControlDataBindings(textBoxBoundsMaxWeight, miscOpt, nameof(CoreLib.Bounds.MaxWeight), true); // "MaxWeight"
-      SetControlDataBindings(textBoxBoundsNatMortality, miscOpt, nameof(CoreLib.Bounds.MaxNatMort), true); //"MaxNatMort"
+      SetupTextBoxDataBindings(textBoxBoundsMaxWeight, miscOpt, nameof(CoreLib.Bounds.MaxWeight), true); // "MaxWeight"
+      SetupTextBoxDataBindings(textBoxBoundsNatMortality, miscOpt, nameof(CoreLib.Bounds.MaxNatMort), true); //"MaxNatMort"
     }
 
     /// <summary>
@@ -237,7 +237,7 @@ namespace Nmfs.Agepro.Gui
     /// <param name="miscOptSrc"> Generalized class that encapsulates AGEPRO's <see cref="CoreLib.AgeproOptionsProperty"/> Classes </param>
     /// <param name="miscOptField"> Field names of specfic <see cref="AgeproOptionsProperty"/> class.</param>
     /// <param name="decimalZeroFormat">Boolean flag to format to include point-decimal values.  </param>
-    private void SetControlDataBindings(NftTextBox ctl, CoreLib.AgeproOptionsProperty miscOptSrc, string miscOptField,
+    private void SetupTextBoxDataBindings(NftTextBox ctl, CoreLib.AgeproOptionsProperty miscOptSrc, string miscOptField,
       bool decimalZeroFormat = false)
     {
       //Clear any existing (if any) bindings before creating new ones.

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -26,6 +26,7 @@ namespace Nmfs.Agepro.Gui
     private const string DefaultRefMeanBiomass = "0.0";
     private const string DefaultRefSpawnBiomass = "0.0";
     private const string DefaultRefFishingMortality = "0.0";
+    private const int DefaultLargeFileLineCount = 1000000;
 
     public int miscOptionsNAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
@@ -455,25 +456,27 @@ namespace Nmfs.Agepro.Gui
     /// Size equals timeHorizon * numRealizations, which numRealizations is numBootstraps * numSims</param>
     /// <param name="largeFileRowCount">Default to 1000000 </param>
     /// <returns></returns>
-    public bool CheckOutputFileRowSize(int auxFileRowSize, int largeFileRowCount = 1000000)
+    public bool CheckOutputFileRowSize(int auxFileRowSize, int largeFileRowCount = DefaultLargeFileLineCount)
     {
-      if (auxFileRowSize > largeFileRowCount)
+      if (auxFileRowSize <= largeFileRowCount)
       {
-        DialogResult outputFileSizePrompt;
+        return true;
+      }
 
-        if (MiscOptionsEnableSummaryReport || MiscOptionsEnableAuxStochasticFiles)
+      DialogResult outputFileSizePrompt;
+
+      if (MiscOptionsEnableSummaryReport || MiscOptionsEnableAuxStochasticFiles)
+      {
+        outputFileSizePrompt = MessageBox.Show(
+          "The number of realizations times the number of projected years is greater than " +
+          largeFileRowCount + ". This will produce large auxiliary output files. " +
+          "This will affect the performance of calculation engine." +
+          Environment.NewLine + Environment.NewLine + "Do you wish to procced?",
+          "AGEPRO", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+
+        if (outputFileSizePrompt == DialogResult.No)
         {
-          outputFileSizePrompt = MessageBox.Show(
-            "The number of realizations times the number of projected years is greater than " +
-            largeFileRowCount + ". This will produce large auxiliary output files. " +
-            "This will affect the performance of calculation engine." +
-            Environment.NewLine + Environment.NewLine + "Do you wish to procced?",
-            "AGEPRO", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
-
-          if (outputFileSizePrompt == DialogResult.No)
-          {
-            return false;
-          }
+          return false;
         }
       }
       return true;

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -162,11 +162,15 @@ namespace Nmfs.Agepro.Gui
     #region Controls Setup
 
     /// <summary>
-    /// Sets which Stock Summary Flag RadioBoxes to based on AGEPRO Input 
+    /// Sets which Auxilary Output/Stock Summary Flag RadioBoxes to based on AGEPRO Input 
     /// File's StockSummaryFlag Value.
+    /// 
+    /// Values are bases on the input numeric paramenter "inpData", referenced as AuxiliaryOutputFlag
+    /// Enum.
+    /// 
     /// </summary>
-    /// <param name="inpData">Parameter data for OPTIONS Keywrod parameter 
-    /// from the AGEPRO Input File</param>
+    /// <param name="inpData"> Misc OPTIONS Keyword parameter input data object containing the  
+    /// OutputSummaryFlag/AuxillaryOutputReport numeric value. </param>
     /// <exception cref="InvalidEnumArgumentException"></exception>
     public void SetupGroupSummaryStockFlag(AgeproMiscOptions inpData)
     {

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -488,7 +488,7 @@ namespace Nmfs.Agepro.Gui
     /// Sets up Retro Adjustment Factors in Misc Options Panel when a new Agepro Model is created via interface.
     /// </summary>
     /// <param name="general">AGEPRO Genereal Parameters Control used to pass the Number of Ages</param>
-    public void SetupRetroAdjustmentFactorsControlFromUserInput(ControlGeneral general)
+    public void SetupRetroAdjustmentsFactorControl(ControlGeneral general)
     {  
       //In case NumAges is larger than previous row count, "reset" dataGridView 
       if (MiscOptionsRetroAdjustmentFactorTable != null

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -336,7 +336,7 @@ namespace Nmfs.Agepro.Gui
     /// </summary>
     /// <param name="inputFile"> AGEPRO Input File </param>
     /// <exception cref="ArgumentNullException"></exception>
-    public void SetMiscOptionsControlsFromInputFile(AgeproInputFile inputFile)
+    public void SetupControlFromFile(AgeproInputFile inputFile)
     {
       if (inputFile is null)
       {

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -168,7 +168,7 @@ namespace Nmfs.Agepro.Gui
 
     /// <summary>
     /// Sets which Auxilary Output/Stock Summary Flag RadioBoxes to based on AGEPRO Input 
-    /// File's StockSummaryFlag Value.
+    /// File's StockSummaryFlag Value. 
     /// 
     /// Values are bases on the input numeric paramenter "inpData", referenced as AuxiliaryOutputFlag
     /// Enum.
@@ -183,19 +183,19 @@ namespace Nmfs.Agepro.Gui
 
       if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.NoStockAge_ExcludeStockNumAuxFile)
       {
-        radioButtonOutfileNoStockExcludeStockAux.Checked = true;
+        radioButtonNoStockAge_ExcludeStockNumAux.Checked = true;
       }
       else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.StockAge_AllAuxFiles)
       {
-        radioButtonOutfileAppendStockAllAux.Checked = true;
+        radioButtonStockAge_AllAux.Checked = true;
       }
       else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.NoStockAge_NoAuxFiles)
       {
-        radioButtonOnlyOutfileNoStock.Checked = true;
+        radioButtonNoStockAge_NoAux.Checked = true;
       }
       else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.StockAge_NoAuxFiles)
       {
-        radioButtonOnlyOutfileAppendStock.Checked = true;
+        radioButtonStockAge_NoAux.Checked = true;
       }
       else 
       {
@@ -677,33 +677,62 @@ namespace Nmfs.Agepro.Gui
       }
     }
 
-    private void RadioButtonNone_CheckedChanged(object sender, EventArgs e)
+
+    #endregion
+
+    private void checkBoxVer40Format_CheckedChanged(object sender, EventArgs e)
     {
-      //TODO: Set
-      //SummaryAuxFileOutputFlag = (AuxiliaryOutputFlag)inpData.OutputSummaryReport
-      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.NoStockAge_ExcludeStockNumAuxFile;
+      radioButtonNoStockAge_NoAux.Enabled = !checkBoxVer40Format.Checked;
+      radioButtonStockAge_NoAux.Enabled = !checkBoxVer40Format.Checked;
+      radioButtonStockAge_ExcludeStockNumAux.Enabled = !checkBoxVer40Format.Checked;
     }
 
-    private void RadioButtonSummaryOnly_CheckedChanged(object sender, EventArgs e)
+    /// <summary>
+    /// Radio Button button event to handkle when First option of "Stock Distribution Summary and Auxiliary Data Files" is Checked.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void radioButtonNoStockAge_ExcludeStockNumAux_CheckedChanged(object sender, EventArgs e)
+    {
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.NoStockAge_ExcludeStockNumAuxFile;
+    }
+    /// <summary>
+    /// Radio Button button event to handkle when Second option of "Stock Distribution Summary and Auxiliary Data Files" is Checked.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void radioButtonStockAge_AllAux_CheckedChanged(object sender, EventArgs e)
     {
       SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.StockAge_AllAuxFiles;
     }
-
-    private void RadioButtonSummaryNoAux1_CheckedChanged(object sender, EventArgs e)
+    /// <summary>
+    /// Radio Button button event to handkle when Third option of "Stock Distribution Summary and Auxiliary Data Files" is Checked.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void radioButtonNoStockAge_NoAux_CheckedChanged(object sender, EventArgs e)
     {
       SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.NoStockAge_NoAuxFiles;
     }
-
-    private void RadioButtonSummaryPlusAllAux_CheckedChanged(object sender, EventArgs e)
+    /// <summary>
+    /// Radio Button button event to handkle when Fourth option of "Stock Distribution Summary and Auxiliary Data Files" is Checked.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void radioButtonStockAge_NoAux_CheckedChanged(object sender, EventArgs e)
     {
       SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.StockAge_NoAuxFiles;
     }
-
-    private void CheckBoxEnableSummaryReport_CheckedChanged(object sender, EventArgs e)
+    /// <summary>
+    /// Radio Button button event to handkle when Fifth option of "Stock Distribution Summary and Auxiliary Data Files" is Checked.
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void radioButtonStockAge_ExcludeStockNumAux_CheckedChanged(object sender, EventArgs e)
     {
       SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.StockAge_ExcludeStockNumAuxFile;
     }
 
-    #endregion
+
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -155,10 +155,10 @@ namespace Nmfs.Agepro.Gui
     /// <param name="miscOpt">Refrerence Points Option Object</param>
     public void SetupRefpointDataBindings(CoreLib.Refpoint miscOpt)
     {
-      SetControlDataBindings(textBoxRefSpawnBiomass, miscOpt, "refSpawnBio");
-      SetControlDataBindings(textBoxRefJan1Biomass, miscOpt, "refJan1Bio");
-      SetControlDataBindings(textBoxRefMeanBiomass, miscOpt, "refMeanBio");
-      SetControlDataBindings(textBoxRefFishMortality, miscOpt, "refFMort");
+      SetControlDataBindings(textBoxRefSpawnBiomass, miscOpt, nameof(CoreLib.Refpoint.RefSpawnBio)); // "RefSpawnBio"
+      SetControlDataBindings(textBoxRefJan1Biomass, miscOpt, nameof(CoreLib.Refpoint.RefJan1Bio)); // "RefJan1Bio"
+      SetControlDataBindings(textBoxRefMeanBiomass, miscOpt, nameof(CoreLib.Refpoint.RefMeanBio)); // "RefMeanBio"
+      SetControlDataBindings(textBoxRefFishMortality, miscOpt, nameof(CoreLib.Refpoint.RefFMort)); // "RefFMort"
     }
 
     /// <summary>
@@ -167,9 +167,9 @@ namespace Nmfs.Agepro.Gui
     /// <param name="miscOpt">AGEPRO CoreLib Misc Options Object</param>
     public void SetupScaleFactorsDataBindings(CoreLib.ScaleFactors miscOpt)
     {
-      SetControlDataBindings(textBoxScaleFactorBiomass, miscOpt, "scaleBio");
-      SetControlDataBindings(textBoxScaleFactorRecruits, miscOpt, "scaleRec");
-      SetControlDataBindings(textBoxScaleFactorsStockNum, miscOpt, "scaleStockNum");
+      SetControlDataBindings(textBoxScaleFactorBiomass, miscOpt, nameof(CoreLib.ScaleFactors.ScaleBio)); // "ScaleBio"
+      SetControlDataBindings(textBoxScaleFactorRecruits, miscOpt, nameof(CoreLib.ScaleFactors.ScaleRec)); // "ScaleRec"
+      SetControlDataBindings(textBoxScaleFactorsStockNum, miscOpt, nameof(CoreLib.ScaleFactors.ScaleStockNum)); // "ScaleStockNum"
     }
 
     /// <summary>
@@ -178,8 +178,8 @@ namespace Nmfs.Agepro.Gui
     /// <param name="miscOpt">AGEPRO CoreLib Misc Options Object</param>
     public void SetupBoundsDataBindings(CoreLib.Bounds miscOpt)
     {
-      SetControlDataBindings(textBoxBoundsMaxWeight, miscOpt, "maxWeight", true);
-      SetControlDataBindings(textBoxBoundsNatMortality, miscOpt, "maxNatMort", true);
+      SetControlDataBindings(textBoxBoundsMaxWeight, miscOpt, nameof(CoreLib.Bounds.MaxWeight), true); // "MaxWeight"
+      SetControlDataBindings(textBoxBoundsNatMortality, miscOpt, nameof(CoreLib.Bounds.MaxNatMort), true); //"MaxNatMort"
     }
 
     /// <summary>

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -328,7 +328,6 @@ namespace Nmfs.Agepro.Gui
     public void ControlMiscOptionsDataBindings(AgeproInputFile inputFile)
     {
       //Misc options
-      inputFile.Options.OutputSummaryReport = (int)SummaryAuxFileOutputFlag;
       inputFile.Options.EnableExportR = MiscOptionsEnableExportR;
       inputFile.Options.EnableAuxStochasticFiles = MiscOptionsEnableAuxStochasticFiles;
       inputFile.Options.EnablePercentileReport = MiscOptionsEnablePercentileReport;
@@ -336,6 +335,10 @@ namespace Nmfs.Agepro.Gui
       inputFile.Options.EnableScaleFactors = MiscOptionsEnableScaleFactors;
       inputFile.Options.EnableBounds = MiscOptionsBounds;
       inputFile.Options.EnableRetroAdjustmentFactors = MiscOptionsEnableRetroAdjustmentFactors;
+
+      //Misc options: Auxiliary Output Flag/Summary Output Report
+      inputFile.Options.OutputSummaryReport = (int)SummaryAuxFileOutputFlag;
+      inputFile.Options.EnableSummaryReport = Convert.ToBoolean((int)SummaryAuxFileOutputFlag);
 
       //Misc Options: Refpoint
       inputFile.Refpoint.RefSpawnBio = double.Parse(MiscOptionsRefSpawnBiomass);

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -1,5 +1,4 @@
 ﻿using Nmfs.Agepro.CoreLib;
-using Nmfs.Agepro.CoreLib.src.coreLib.options;
 using System;
 using System.Collections.Generic;
 using System.Data;

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -57,6 +57,9 @@ namespace Nmfs.Agepro.Gui
 
       //Report Percentile
       MiscOptionsReportPercentile = 0;
+
+      SummaryAuxFileOutput = StockSummaryFlag.None;
+
     }
 
     public bool MiscOptionsEnableSummaryReport
@@ -529,6 +532,31 @@ namespace Nmfs.Agepro.Gui
       {
         SetRetroAdjustmentFactorRowHeaders();
       }
+    }
+
+    private void RadioButtonNone_CheckedChanged(object sender, EventArgs e)
+    {
+      SummaryAuxFileOutput = StockSummaryFlag.None;
+    }
+
+    private void RadioButtonSummaryOnly_CheckedChanged(object sender, EventArgs e)
+    {
+      SummaryAuxFileOutput = StockSummaryFlag.SummaryOnly;
+    }
+
+    private void RadioButtonSummaryNoAux1_CheckedChanged(object sender, EventArgs e)
+    {
+      SummaryAuxFileOutput = StockSummaryFlag.SummaryPlusAux2_10;
+    }
+
+    private void RadioButtonSummaryPlusAllAux_CheckedChanged(object sender, EventArgs e)
+    {
+      SummaryAuxFileOutput = StockSummaryFlag.SummaryPlusAllAux;
+    }
+
+    private void CheckBoxEnableSummaryReport_CheckedChanged(object sender, EventArgs e)
+    {
+
     }
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -323,7 +323,7 @@ namespace Nmfs.Agepro.Gui
       inputFile.Scale.ScaleStockNum = double.Parse(MiscOptionsScaleFactorStockNumbers);
 
       //Misc Options: Retro Adjustment Factors
-      inputFile.RetroAdjustments.RetroAdjust = MiscOptionsRetroAdjustmentFactorTable;
+      inputFile.RetroAdjustment.RetroAdjust = MiscOptionsRetroAdjustmentFactorTable;
     }
 
     #endregion
@@ -377,11 +377,11 @@ namespace Nmfs.Agepro.Gui
 
       // Retro Adjustment Factors 
       MiscOptionsEnableRetroAdjustmentFactors = inputFile.Options.EnableRetroAdjustmentFactors;
-      LoadRetroAdjustmentsFactorTable(inputFile);
+      LoadRetroAdjustment(inputFile);
       
       if (MiscOptionsEnableRetroAdjustmentFactors)
       {
-        SetupRetroAdjustmentsFactorRowHeaders();
+        SetupRetroAdjustmentRowHeader();
       }
 
       //OuputSummaryFlag Radio Buttons
@@ -479,7 +479,7 @@ namespace Nmfs.Agepro.Gui
     }
     #endregion
 
-    #region RetroAdjustmentsFactorTable
+    #region RetroAdjustmentFactorTable
     /*
      * Retro Adjustment Factor Data Table Interface
      */
@@ -488,7 +488,7 @@ namespace Nmfs.Agepro.Gui
     /// Sets up Retro Adjustment Factors in Misc Options Panel when a new Agepro Model is created via interface.
     /// </summary>
     /// <param name="general">AGEPRO Genereal Parameters Control used to pass the Number of Ages</param>
-    public void SetupRetroAdjustmentsFactorControl(ControlGeneral general)
+    public void SetupRetroAdjustmentControl(ControlGeneral general)
     {  
       //In case NumAges is larger than previous row count, "reset" dataGridView 
       if (MiscOptionsRetroAdjustmentFactorTable != null
@@ -497,14 +497,14 @@ namespace Nmfs.Agepro.Gui
         MiscOptionsRetroAdjustmentFactorTable.Reset();
       }
       MiscOptionsRetroAdjustmentFactorTable =
-          GetRetroAdjustmentFallbackTable(miscOptionsNumAges);
-      SetupRetroAdjustmentsFactorRowHeaders();
+          FallbackRetroAdjustmentTable(miscOptionsNumAges);
+      SetupRetroAdjustmentRowHeader();
     }
 
     /// <summary>
     /// Sets Up Row Headers For the Retro Adujustment Data Grid Table
     /// </summary>
-    public void SetupRetroAdjustmentsFactorRowHeaders()
+    public void SetupRetroAdjustmentRowHeader()
     {
       dataGridRetroAdjustment.RowHeadersVisible = true;
       for (int iage = 0; iage < miscOptionsNumAges; iage++)
@@ -520,13 +520,13 @@ namespace Nmfs.Agepro.Gui
     /// Helper Function to Load The Retro Adjustments Data Grid from AGEPRO Input File
     /// </summary>
     /// <param name="inputFile">AGEPRO Input File Object</param>
-    public void LoadRetroAdjustmentsFactorTable(AgeproInputFile inputFile)
+    public void LoadRetroAdjustment(AgeproInputFile inputFile)
     {
       if (MiscOptionsRetroAdjustmentFactorTable != null)
       {
         MiscOptionsRetroAdjustmentFactorTable.Reset();
       }
-      MiscOptionsRetroAdjustmentFactorTable = inputFile.RetroAdjustments.RetroAdjust;
+      MiscOptionsRetroAdjustmentFactorTable = inputFile.RetroAdjustment.RetroAdjust;
     }
 
     /// <summary>
@@ -535,7 +535,7 @@ namespace Nmfs.Agepro.Gui
     /// </summary>
     /// <param name="numAges">Number of age rows. Each row represents an age.</param>
     /// <returns>Returns a single column Data Table populated with 0.</returns>
-    public DataTable GetRetroAdjustmentFallbackTable(int numAges)
+    public DataTable FallbackRetroAdjustmentTable(int numAges)
     {
       //Create a Single Column Table for the data grid view. Each row represents an age.
       DataTable fallbackTable = new DataTable();
@@ -640,9 +640,9 @@ namespace Nmfs.Agepro.Gui
       else
       {
         //If Checked, create fallback defualt data table.
-        dataGridRetroAdjustment.DataSource = GetRetroAdjustmentFallbackTable(miscOptionsNumAges);
+        dataGridRetroAdjustment.DataSource = FallbackRetroAdjustmentTable(miscOptionsNumAges);
 
-        SetupRetroAdjustmentsFactorRowHeaders();
+        SetupRetroAdjustmentRowHeader();
 
       }
     }
@@ -659,7 +659,7 @@ namespace Nmfs.Agepro.Gui
       //header value is null
       if (e.ColumnIndex == 0)
       {
-        SetupRetroAdjustmentsFactorRowHeaders();
+        SetupRetroAdjustmentRowHeader();
       }
     }
 

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -57,7 +57,7 @@ namespace Nmfs.Agepro.Gui
       //Report Percentile
       MiscOptionsReportPercentile = 0;
 
-      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OutfileNoStockExcludeStockAux;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.NoStockAge_ExcludeStockNumAuxFile;
 
     }
 
@@ -172,19 +172,19 @@ namespace Nmfs.Agepro.Gui
     {
       SummaryAuxFileOutputFlag = (AuxiliaryOutputFlag)inpData.OutputSummaryReport;
 
-      if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.OutfileNoStockExcludeStockAux)
+      if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.NoStockAge_ExcludeStockNumAuxFile)
       {
         radioButtonOutfileNoStockExcludeStockAux.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.OutfileAppendStockAllAux)
+      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.StockAge_AllAuxFiles)
       {
         radioButtonOutfileAppendStockAllAux.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.OnlyOutfileNoStock)
+      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.NoStockAge_NoAuxFiles)
       {
         radioButtonOnlyOutfileNoStock.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.OnlyOutfileAppendStock)
+      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.StockAge_NoAuxFiles)
       {
         radioButtonOnlyOutfileAppendStock.Checked = true;
       }
@@ -667,27 +667,29 @@ namespace Nmfs.Agepro.Gui
 
     private void RadioButtonNone_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OutfileNoStockExcludeStockAux;
+      //TODO: Set
+      //SummaryAuxFileOutputFlag = (AuxiliaryOutputFlag)inpData.OutputSummaryReport
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.NoStockAge_ExcludeStockNumAuxFile;
     }
 
     private void RadioButtonSummaryOnly_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OutfileAppendStockAllAux;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.StockAge_AllAuxFiles;
     }
 
     private void RadioButtonSummaryNoAux1_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OnlyOutfileNoStock;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.NoStockAge_NoAuxFiles;
     }
 
     private void RadioButtonSummaryPlusAllAux_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OnlyOutfileAppendStock;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.StockAge_NoAuxFiles;
     }
 
     private void CheckBoxEnableSummaryReport_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OutfileAppendStockExcludeStockAux;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.StockAge_ExcludeStockNumAuxFile;
     }
 
     #endregion

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -31,7 +31,7 @@ namespace Nmfs.Agepro.Gui
 
     public int miscOptionsNumAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
-    public StockSummaryFlag SummaryAuxFileOutputFlag { get; set; }
+    public AuxiliaryOutputFlag SummaryAuxFileOutputFlag { get; set; }
     
     public ControlMiscOptions()
     {
@@ -58,7 +58,7 @@ namespace Nmfs.Agepro.Gui
       //Report Percentile
       MiscOptionsReportPercentile = 0;
 
-      SummaryAuxFileOutputFlag = StockSummaryFlag.NoStockDistAllAux;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OutfileNoStockExcludeStockAux;
 
     }
 
@@ -174,23 +174,23 @@ namespace Nmfs.Agepro.Gui
     /// <exception cref="InvalidEnumArgumentException"></exception>
     public void SetupGroupSummaryStockFlag(AgeproMiscOptions inpData)
     {
-      SummaryAuxFileOutputFlag = (StockSummaryFlag)inpData.OutputSummaryReport;
+      SummaryAuxFileOutputFlag = (AuxiliaryOutputFlag)inpData.OutputSummaryReport;
 
-      if (SummaryAuxFileOutputFlag == StockSummaryFlag.NoStockDistAllAux)
+      if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.OutfileNoStockExcludeStockAux)
       {
-        radioButtonNoStockDistAllAux.Checked = true;
+        radioButtonOutfileNoStockExcludeStockAux.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.StockDistAllAux)
+      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.OutfileAppendStockAllAux)
       {
-        radioButtonStockDistAllAux.Checked = true;
+        radioButtonOutfileAppendStockAllAux.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.StockDistNoAux)
+      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.OnlyOutfileNoStock)
       {
-        radioButtonSummaryStockDistNoAux.Checked = true;
+        radioButtonOnlyOutfileNoStock.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.StockDistExceptAuxStockVector)
+      else if (SummaryAuxFileOutputFlag == AuxiliaryOutputFlag.OnlyOutfileAppendStock)
       {
-        radioButtonStockDistExceptAuxStockVector.Checked = true;
+        radioButtonOnlyOutfileAppendStock.Checked = true;
       }
       else 
       {
@@ -356,7 +356,7 @@ namespace Nmfs.Agepro.Gui
 
       // Options (w/ OutputSummaryFlag)
       MiscOptionsEnableSummaryReport = inputFile.Options.EnableSummaryReport; 
-      SummaryAuxFileOutputFlag = (StockSummaryFlag)inputFile.Options.OutputSummaryReport;
+      SummaryAuxFileOutputFlag = (AuxiliaryOutputFlag)inputFile.Options.OutputSummaryReport;
       
       MiscOptionsEnableAuxStochasticFiles = inputFile.Options.EnableAuxStochasticFiles;
       MiscOptionsEnableExportR = inputFile.Options.EnableExportR;
@@ -673,27 +673,27 @@ namespace Nmfs.Agepro.Gui
 
     private void RadioButtonNone_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = StockSummaryFlag.NoStockDistAllAux;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OutfileNoStockExcludeStockAux;
     }
 
     private void RadioButtonSummaryOnly_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = StockSummaryFlag.StockDistAllAux;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OutfileAppendStockAllAux;
     }
 
     private void RadioButtonSummaryNoAux1_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = StockSummaryFlag.StockDistNoAux;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OnlyOutfileNoStock;
     }
 
     private void RadioButtonSummaryPlusAllAux_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = StockSummaryFlag.StockDistExceptAuxStockVector;
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OnlyOutfileAppendStock;
     }
 
     private void CheckBoxEnableSummaryReport_CheckedChanged(object sender, EventArgs e)
     {
-
+      SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.OutfileAppendStockExcludeStockAux;
     }
 
     #endregion

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -263,6 +263,7 @@ namespace Nmfs.Agepro.Gui
     {
       //Misc options
       inputFile.Options.EnableSummaryReport = MiscOptionsEnableSummaryReport;
+      inputFile.Options.OutputSummaryReport = (int)SummaryAuxFileOutputFlag;
       inputFile.Options.EnableExportR = MiscOptionsEnableExportR;
       inputFile.Options.EnableAuxStochasticFiles = MiscOptionsEnableAuxStochasticFiles;
       inputFile.Options.EnablePercentileReport = MiscOptionsEnablePercentileReport;

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -28,7 +28,7 @@ namespace Nmfs.Agepro.Gui
     private const string DefaultRefFishingMortality = "0.0";
     private const int DefaultLargeFileLineCount = 1000000;
 
-    public int miscOptionsNAges { get; set; }
+    public int miscOptionsNumAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
     public StockSummaryFlag SummaryAuxFileOutputFlag { get; set; }
     
@@ -343,7 +343,7 @@ namespace Nmfs.Agepro.Gui
         throw new ArgumentNullException(nameof(inputFile));
       }
 
-      miscOptionsNAges = inputFile.General.NumAges();
+      miscOptionsNumAges = inputFile.General.NumAges();
       miscOptionsFirstAge = inputFile.General.AgeBegin;
 
       // Options (w/ OutputSummaryFlag)
@@ -497,7 +497,7 @@ namespace Nmfs.Agepro.Gui
         MiscOptionsRetroAdjustmentFactorTable.Reset();
       }
       MiscOptionsRetroAdjustmentFactorTable =
-          GetRetroAdjustmentFallbackTable(miscOptionsNAges);
+          GetRetroAdjustmentFallbackTable(miscOptionsNumAges);
       SetRetroAdjustmentFactorRowHeaders();
     }
 
@@ -507,7 +507,7 @@ namespace Nmfs.Agepro.Gui
     public void SetRetroAdjustmentFactorRowHeaders()
     {
       dataGridRetroAdjustment.RowHeadersVisible = true;
-      for (int iage = 0; iage < miscOptionsNAges; iage++)
+      for (int iage = 0; iage < miscOptionsNumAges; iage++)
       {
         //Accomidate 0-based or 1-based First Age Models
         int iageForHeader = iage + miscOptionsFirstAge;
@@ -640,7 +640,7 @@ namespace Nmfs.Agepro.Gui
       else
       {
         //If Checked, create fallback defualt data table.
-        dataGridRetroAdjustment.DataSource = GetRetroAdjustmentFallbackTable(miscOptionsNAges);
+        dataGridRetroAdjustment.DataSource = GetRetroAdjustmentFallbackTable(miscOptionsNumAges);
 
         SetRetroAdjustmentFactorRowHeaders();
 

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -333,6 +333,47 @@ namespace Nmfs.Agepro.Gui
       }
     }
 
+    public void SetMiscOptionsControlsFromInputFile(AgeproInputFile inputFile)
+    {
+      if (inputFile is null)
+      {
+        throw new ArgumentNullException(nameof(inputFile));
+      }
+
+      this.MiscOptionsEnableSummaryReport = inputFile.Options.EnableSummaryReport;
+      this.MiscOptionsEnableAuxStochasticFiles = inputFile.Options.EnableAuxStochasticFiles;
+      this.MiscOptionsEnableExportR = inputFile.Options.EnableExportR;
+      this.MiscOptionsEnablePercentileReport = inputFile.Options.EnablePercentileReport;
+      this.MiscOptionsReportPercentile = Convert.ToDouble(inputFile.ReportPercentile.Percentile);
+
+      this.MiscOptionsEnableRefpointsReport = inputFile.Options.EnableRefpoint;
+      this.MiscOptionsRefSpawnBiomass = inputFile.Refpoint.RefSpawnBio.ToString();
+      this.MiscOptionsRefJan1Biomass = inputFile.Refpoint.RefJan1Bio.ToString();
+      this.MiscOptionsRefMeanBiomass = inputFile.Refpoint.RefMeanBio.ToString();
+      this.MiscOptionsRefFishingMortality = inputFile.Refpoint.RefFMort.ToString();
+
+      this.MiscOptionsEnableScaleFactors = inputFile.Options.EnableScaleFactors;
+      this.MiscOptionsScaleFactorBiomass = inputFile.Scale.ScaleBio.ToString();
+      this.MiscOptionsScaleFactorRecruits = inputFile.Scale.ScaleRec.ToString();
+      this.MiscOptionsScaleFactorStockNumbers = inputFile.Scale.ScaleStockNum.ToString();
+
+      this.MiscOptionsBounds = inputFile.Options.EnableBounds;
+      this.MiscOptionsBoundsMaxWeight = inputFile.Bounds.MaxWeight.ToString();
+      this.MiscOptionsBoundsNaturalMortality = inputFile.Bounds.MaxNatMort.ToString();
+
+      this.MiscOptionsEnableRetroAdjustmentFactors = inputFile.Options.EnableRetroAdjustmentFactors;
+      this.miscOptionsNAges = inputFile.General.NumAges();
+      this.miscOptionsFirstAge = inputFile.General.AgeBegin;
+
+      this.LoadRetroAdjustmentsFactorTable(inputFile);
+
+      if (this.MiscOptionsEnableRetroAdjustmentFactors)
+      {
+        this.SetRetroAdjustmentFactorRowHeaders();
+      }
+    }
+
+
     /// <summary>
     /// Input Validation
     /// </summary>

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -160,6 +160,15 @@ namespace Nmfs.Agepro.Gui
       get => (DataTable)dataGridRetroAdjustment.DataSource;
       set => dataGridRetroAdjustment.DataSource = value;
     }
+    //Check Box for "AGEPRO VERSION 4.0" format.
+    //If (valid and compatable) version string isn't "AGEPRO VERSION 4.0" set to FALSE
+    public bool MiscOptionsEnableVer40Format
+    {
+      get => checkBoxEnableVer40Format.Checked;
+      set => checkBoxEnableVer40Format.Checked = value;
+
+    }
+
     public string AgeproOutputViewer => comboBoxOutputViewerProgram.SelectedItem.ToString();
 
     #endregion
@@ -679,12 +688,11 @@ namespace Nmfs.Agepro.Gui
 
 
     #endregion
-
-    private void checkBoxVer40Format_CheckedChanged(object sender, EventArgs e)
+    private void checkBoxEnableVer40Format_CheckedChanged(object sender, EventArgs e)
     {
-      radioButtonNoStockAge_NoAux.Enabled = !checkBoxVer40Format.Checked;
-      radioButtonStockAge_NoAux.Enabled = !checkBoxVer40Format.Checked;
-      radioButtonStockAge_ExcludeStockNumAux.Enabled = !checkBoxVer40Format.Checked;
+      radioButtonNoStockAge_NoAux.Enabled = !checkBoxEnableVer40Format.Checked;
+      radioButtonStockAge_NoAux.Enabled = !checkBoxEnableVer40Format.Checked;
+      radioButtonStockAge_ExcludeStockNumAux.Enabled = !checkBoxEnableVer40Format.Checked;
     }
 
     /// <summary>

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -381,7 +381,7 @@ namespace Nmfs.Agepro.Gui
       
       if (MiscOptionsEnableRetroAdjustmentFactors)
       {
-        SetRetroAdjustmentFactorRowHeaders();
+        SetupRetroAdjustmentsFactorRowHeaders();
       }
 
       //OuputSummaryFlag Radio Buttons
@@ -498,13 +498,13 @@ namespace Nmfs.Agepro.Gui
       }
       MiscOptionsRetroAdjustmentFactorTable =
           GetRetroAdjustmentFallbackTable(miscOptionsNumAges);
-      SetRetroAdjustmentFactorRowHeaders();
+      SetupRetroAdjustmentsFactorRowHeaders();
     }
 
     /// <summary>
     /// Sets Up Row Headers For the Retro Adujustment Data Grid Table
     /// </summary>
-    public void SetRetroAdjustmentFactorRowHeaders()
+    public void SetupRetroAdjustmentsFactorRowHeaders()
     {
       dataGridRetroAdjustment.RowHeadersVisible = true;
       for (int iage = 0; iage < miscOptionsNumAges; iage++)
@@ -642,7 +642,7 @@ namespace Nmfs.Agepro.Gui
         //If Checked, create fallback defualt data table.
         dataGridRetroAdjustment.DataSource = GetRetroAdjustmentFallbackTable(miscOptionsNumAges);
 
-        SetRetroAdjustmentFactorRowHeaders();
+        SetupRetroAdjustmentsFactorRowHeaders();
 
       }
     }
@@ -659,7 +659,7 @@ namespace Nmfs.Agepro.Gui
       //header value is null
       if (e.ColumnIndex == 0)
       {
-        SetRetroAdjustmentFactorRowHeaders();
+        SetupRetroAdjustmentsFactorRowHeaders();
       }
     }
 

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -166,21 +166,8 @@ namespace Nmfs.Agepro.Gui
     //If (valid and compatable) version string isn't "AGEPRO VERSION 4.0" set to FALSE
     public bool MiscOptionsEnableVer40Format
     {
-      get => checkBoxEnableVer40Format.Checked;
-      set
-      {
-        checkBoxEnableVer40Format.Checked = value;
-        if (MiscOptionsEnableVer40Format)
-        {
-          MiscOptionsInpfileFormat = CoreLib.Resources.Version.INP_AGEPRO40_VersionString;
-          
-        }
-        else
-        {
-          MiscOptionsInpfileFormat = CoreLib.Resources.Version.INP_VersionString;
-        }
-
-      }
+      get => checkBoxEnableVer40Format.Checked; 
+      set => checkBoxEnableVer40Format.Checked = value;
     }
 
     public string AgeproOutputViewer => comboBoxOutputViewerProgram.SelectedItem.ToString();
@@ -264,6 +251,13 @@ namespace Nmfs.Agepro.Gui
     {
       SetupTextBoxDataBindings(textBoxBoundsMaxWeight, miscOpt, nameof(CoreLib.Bounds.MaxWeight), true); // "MaxWeight"
       SetupTextBoxDataBindings(textBoxBoundsNatMortality, miscOpt, nameof(CoreLib.Bounds.MaxNatMort), true); //"MaxNatMort"
+    }
+
+    public void SetupMiscOptionsInpfileVerStringDataBindings(CoreLib.AgeproInputFile inpfile)
+    {
+      textBoxMiscOptionsInpfileVerString.DataBindings.Clear();
+      _ = textBoxMiscOptionsInpfileVerString.DataBindings.Add("Text", inpfile, nameof(AgeproInputFile.Version), true,
+                                                              DataSourceUpdateMode.OnPropertyChanged);
     }
 
     /// <summary>
@@ -359,6 +353,9 @@ namespace Nmfs.Agepro.Gui
 
       //Misc Options: Retro Adjustment Factors
       inputFile.RetroAdjustment.RetroAdjust = MiscOptionsRetroAdjustmentFactorTable;
+
+      //AGEPRO Input File Format Version
+      inputFile.Version = MiscOptionsInpfileFormat;
     }
 
     #endregion
@@ -709,7 +706,17 @@ namespace Nmfs.Agepro.Gui
       radioButtonNoStockAge_NoAux.Enabled = !checkBoxEnableVer40Format.Checked;
       radioButtonStockAge_NoAux.Enabled = !checkBoxEnableVer40Format.Checked;
       radioButtonStockAge_ExcludeStockNumAux.Enabled = !checkBoxEnableVer40Format.Checked;
-     
+      if (MiscOptionsEnableVer40Format)
+      {
+        textBoxMiscOptionsInpfileVerString.Text = CoreLib.Resources.Version.INP_AGEPRO40_VersionString;
+
+      }
+      else
+      {
+        textBoxMiscOptionsInpfileVerString.Text = CoreLib.Resources.Version.INP_VersionString;
+      }
+
+
     }
 
     /// <summary>

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -1,6 +1,7 @@
 ﻿using Nmfs.Agepro.CoreLib;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Linq;
 using System.Windows.Forms;
@@ -164,6 +165,13 @@ namespace Nmfs.Agepro.Gui
 
     #region Controls Setup
 
+    /// <summary>
+    /// Sets which Stock Summary Flag RadioBoxes to based on AGEPRO Input 
+    /// File's StockSummaryFlag Value.
+    /// </summary>
+    /// <param name="inpData">Parameter data for OPTIONS Keywrod parameter 
+    /// from the AGEPRO Input File</param>
+    /// <exception cref="InvalidEnumArgumentException"></exception>
     public void SetupGroupSummaryStockFlag(AgeproMiscOptions inpData)
     {
       SummaryAuxFileOutputFlag = (StockSummaryFlag)inpData.OutputSummaryReport;
@@ -186,7 +194,7 @@ namespace Nmfs.Agepro.Gui
       }
       else 
       {
-        throw new Exception("Invaild");
+        throw new InvalidEnumArgumentException();
       }
 
     }

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -252,6 +252,43 @@ namespace Nmfs.Agepro.Gui
       sevent.Value = Convert.ToDouble(sevent.Value.ToString());
     }
 
+
+    /// <summary>
+    /// Exports the values that are stored in AgeproMiscOptions Gui Elements and 
+    /// Transfers them to the AGEPRO CoreLib InputFile class values. Typically used
+    /// before AGEPRO Input File Data is written.
+    /// </summary>
+    /// <param name="inputFile">AGEPRO CoreLib Input File Class</param>
+    public void BindMiscOptionsControlValuesToCoreLib(AgeproInputFile inputFile)
+    {
+      //Misc options
+      inputFile.Options.EnableSummaryReport = MiscOptionsEnableSummaryReport;
+      inputFile.Options.EnableExportR = MiscOptionsEnableExportR;
+      inputFile.Options.EnableAuxStochasticFiles = MiscOptionsEnableAuxStochasticFiles;
+      inputFile.Options.EnablePercentileReport = MiscOptionsEnablePercentileReport;
+      inputFile.Options.EnableRefpoint = MiscOptionsEnableRefpointsReport;
+      inputFile.Options.EnableScaleFactors = MiscOptionsEnableScaleFactors;
+      inputFile.Options.EnableBounds = MiscOptionsBounds;
+      inputFile.Options.EnableRetroAdjustmentFactors = MiscOptionsEnableRetroAdjustmentFactors;
+
+      //Misc Options: Refpoint
+      inputFile.Refpoint.RefSpawnBio = double.Parse(MiscOptionsRefSpawnBiomass);
+      inputFile.Refpoint.RefJan1Bio = double.Parse(MiscOptionsRefJan1Biomass);
+      inputFile.Refpoint.RefMeanBio = double.Parse(MiscOptionsRefMeanBiomass);
+      inputFile.Refpoint.RefFMort = double.Parse(MiscOptionsRefFishingMortality);
+
+      //Misc Options: Report Percentile
+      inputFile.ReportPercentile.Percentile = MiscOptionsReportPercentile;
+
+      //Misc Options: Scale Factors
+      inputFile.Scale.ScaleBio = double.Parse(MiscOptionsScaleFactorBiomass);
+      inputFile.Scale.ScaleRec = double.Parse(MiscOptionsScaleFactorRecruits);
+      inputFile.Scale.ScaleStockNum = double.Parse(MiscOptionsScaleFactorStockNumbers);
+
+      //Misc Options: Retro Adjustment Factors
+      inputFile.RetroAdjustments.RetroAdjust = MiscOptionsRetroAdjustmentFactorTable;
+    }
+
     #endregion
 
 

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -192,6 +192,7 @@ namespace Nmfs.Agepro.Gui
     }
 
 
+
     #endregion
 
     #region Setup Data Binding
@@ -472,6 +473,23 @@ namespace Nmfs.Agepro.Gui
     /*
      * Retro Adjustment Factor Data Table Interface
      */
+
+    /// <summary>
+    /// Sets up Retro Adjustment Factors in Misc Options Panel when a new Agepro Model is created via interface.
+    /// </summary>
+    /// <param name="general">AGEPRO Genereal Parameters Control used to pass the Number of Ages</param>
+    public void SetupRetroAdjustmentFactorsControlFromUserInput(ControlGeneral general)
+    {  
+      //In case NumAges is larger than previous row count, "reset" dataGridView 
+      if (MiscOptionsRetroAdjustmentFactorTable != null
+        && general.NumAges() > MiscOptionsRetroAdjustmentFactorTable.Rows.Count)
+      {
+        MiscOptionsRetroAdjustmentFactorTable.Reset();
+      }
+      MiscOptionsRetroAdjustmentFactorTable =
+          GetRetroAdjustmentFallbackTable(miscOptionsNAges);
+      SetRetroAdjustmentFactorRowHeaders();
+    }
 
     /// <summary>
     /// Sets Up Row Headers For the Retro Adujustment Data Grid Table

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -295,7 +295,7 @@ namespace Nmfs.Agepro.Gui
     /// before AGEPRO Input File Data is written.
     /// </summary>
     /// <param name="inputFile">AGEPRO CoreLib Input File Class</param>
-    public void BindMiscOptionsControlValuesToCoreLib(AgeproInputFile inputFile)
+    public void ControlMiscOptionsDataBindings(AgeproInputFile inputFile)
     {
       //Misc options
       inputFile.Options.EnableSummaryReport = MiscOptionsEnableSummaryReport;

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -31,7 +31,6 @@ namespace Nmfs.Agepro.Gui
 
     public int miscOptionsNumAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
-    public AuxiliaryOutputFlag SummaryAuxFileOutputFlag { get; set; }
     
     public ControlMiscOptions()
     {
@@ -64,6 +63,7 @@ namespace Nmfs.Agepro.Gui
 
     #region Getters/Setters
 
+    public AuxiliaryOutputFlag SummaryAuxFileOutputFlag { get; set; }
 
     public bool MiscOptionsEnableAuxStochasticFiles
     {

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -31,6 +31,8 @@ namespace Nmfs.Agepro.Gui
 
     public int miscOptionsNumAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
+    //Local Variable to set inpfile format
+    public string inpfileFormat { get; set; }
     
     public ControlMiscOptions()
     {
@@ -58,6 +60,9 @@ namespace Nmfs.Agepro.Gui
       MiscOptionsReportPercentile = 0;
 
       SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.NoStockAge_ExcludeStockNumAuxFile;
+
+      //By Default, Set inpfile format to version string
+      inpfileFormat = Nmfs.Agepro.CoreLib.Resources.Version.INP_VersionString;
 
     }
 
@@ -349,6 +354,9 @@ namespace Nmfs.Agepro.Gui
       {
         throw new ArgumentNullException(nameof(inputFile));
       }
+
+      //Input File Format
+      inpfileFormat = inputFile.Version;
 
       miscOptionsNumAges = inputFile.General.NumAges();
       miscOptionsFirstAge = inputFile.General.AgeBegin;

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Nmfs.Agepro.CoreLib;
+using Nmfs.Agepro.CoreLib.src.coreLib.options;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -30,6 +31,7 @@ namespace Nmfs.Agepro.Gui
 
     public int miscOptionsNAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
+    public StockSummaryFlag SummaryAuxFileOutput { get; set; }
 
     public ControlMiscOptions()
     {
@@ -528,7 +530,5 @@ namespace Nmfs.Agepro.Gui
         SetRetroAdjustmentFactorRowHeaders();
       }
     }
-
-
   }
 }

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -152,8 +152,8 @@ namespace Nmfs.Agepro.Gui
     /// <summary>
     /// Data Binding setup for Reference Point Options Controls
     /// </summary>
-    /// <param name="miscOpt">AGEPRO CoreLib Misc Options Object</param>
-    public void SetupRefpointDataBindings(CoreLib.AgeproOptionsProperty miscOpt)
+    /// <param name="miscOpt">Refrerence Points Option Object</param>
+    public void SetupRefpointDataBindings(CoreLib.Refpoint miscOpt)
     {
       SetControlDataBindings(textBoxRefSpawnBiomass, miscOpt, "refSpawnBio");
       SetControlDataBindings(textBoxRefJan1Biomass, miscOpt, "refJan1Bio");

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -164,7 +164,7 @@ namespace Nmfs.Agepro.Gui
 
     #region Controls Setup
 
-    public void SetupSummaryStockFlagRadioButtons(AgeproMiscOptions inpData)
+    public void SetupGroupSummaryStockFlag(AgeproMiscOptions inpData)
     {
       SummaryAuxFileOutputFlag = (StockSummaryFlag)inpData.OutputSummaryReport;
 
@@ -385,7 +385,7 @@ namespace Nmfs.Agepro.Gui
       }
 
       //OuputSummaryFlag Radio Buttons
-      SetupSummaryStockFlagRadioButtons(inputFile.Options);
+      SetupGroupSummaryStockFlag(inputFile.Options);
     }
 
     #endregion

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -31,7 +31,7 @@ namespace Nmfs.Agepro.Gui
 
     public int miscOptionsNAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
-    public StockSummaryFlag SummaryAuxFileOutput { get; set; }
+    public StockSummaryFlag SummaryAuxFileOutputFlag { get; set; }
 
     public ControlMiscOptions()
     {
@@ -58,7 +58,7 @@ namespace Nmfs.Agepro.Gui
       //Report Percentile
       MiscOptionsReportPercentile = 0;
 
-      SummaryAuxFileOutput = StockSummaryFlag.None;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.None;
 
     }
 
@@ -307,7 +307,9 @@ namespace Nmfs.Agepro.Gui
       }
 
       this.MiscOptionsEnableSummaryReport = inputFile.Options.EnableSummaryReport;
+      
       this.MiscOptionsEnableAuxStochasticFiles = inputFile.Options.EnableAuxStochasticFiles;
+      this.SummaryAuxFileOutputFlag = (StockSummaryFlag)inputFile.Options.OutputSummaryReport;
       this.MiscOptionsEnableExportR = inputFile.Options.EnableExportR;
       this.MiscOptionsEnablePercentileReport = inputFile.Options.EnablePercentileReport;
       this.MiscOptionsReportPercentile = Convert.ToDouble(inputFile.ReportPercentile.Percentile);
@@ -599,22 +601,22 @@ namespace Nmfs.Agepro.Gui
 
     private void RadioButtonNone_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutput = StockSummaryFlag.None;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.None;
     }
 
     private void RadioButtonSummaryOnly_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutput = StockSummaryFlag.SummaryOnly;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.SummaryOnly;
     }
 
     private void RadioButtonSummaryNoAux1_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutput = StockSummaryFlag.SummaryPlusAux2_10;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.SummaryPlusAux2_10;
     }
 
     private void RadioButtonSummaryPlusAllAux_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutput = StockSummaryFlag.SummaryPlusAllAux;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.SummaryPlusAllAux;
     }
 
     private void CheckBoxEnableSummaryReport_CheckedChanged(object sender, EventArgs e)

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -64,11 +64,7 @@ namespace Nmfs.Agepro.Gui
 
     #region Getters/Setters
 
-    public bool MiscOptionsEnableSummaryReport
-    {
-      get => checkBoxEnableSummaryReport.Checked;
-      set => checkBoxEnableSummaryReport.Checked = value;
-    }
+
     public bool MiscOptionsEnableAuxStochasticFiles
     {
       get => checkBoxEnableAuxStochasticFiles.Checked;
@@ -306,7 +302,6 @@ namespace Nmfs.Agepro.Gui
     public void ControlMiscOptionsDataBindings(AgeproInputFile inputFile)
     {
       //Misc options
-      inputFile.Options.EnableSummaryReport = MiscOptionsEnableSummaryReport;
       inputFile.Options.OutputSummaryReport = (int)SummaryAuxFileOutputFlag;
       inputFile.Options.EnableExportR = MiscOptionsEnableExportR;
       inputFile.Options.EnableAuxStochasticFiles = MiscOptionsEnableAuxStochasticFiles;
@@ -355,7 +350,6 @@ namespace Nmfs.Agepro.Gui
       miscOptionsFirstAge = inputFile.General.AgeBegin;
 
       // Options (w/ OutputSummaryFlag)
-      MiscOptionsEnableSummaryReport = inputFile.Options.EnableSummaryReport; 
       SummaryAuxFileOutputFlag = (AuxiliaryOutputFlag)inputFile.Options.OutputSummaryReport;
       
       MiscOptionsEnableAuxStochasticFiles = inputFile.Options.EnableAuxStochasticFiles;
@@ -469,7 +463,7 @@ namespace Nmfs.Agepro.Gui
 
       DialogResult outputFileSizePrompt;
 
-      if (MiscOptionsEnableSummaryReport || MiscOptionsEnableAuxStochasticFiles)
+      if (MiscOptionsEnableAuxStochasticFiles)
       {
         outputFileSizePrompt = MessageBox.Show(
           "The number of realizations times the number of projected years is greater than " +

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -20,7 +20,7 @@ namespace Nmfs.Agepro.Gui
   /// </list>
   /// </para>
   /// </summary>
-  public partial class ControlMiscOptions : UserControl
+  public partial class ControlMiscOptions : UserControl, IStockSummary
   {
     private const string DefaultRefJan1Biomass = "0.0";
     private const string DefaultRefMeanBiomass = "0.0";
@@ -31,7 +31,7 @@ namespace Nmfs.Agepro.Gui
     public int miscOptionsNAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
     public StockSummaryFlag SummaryAuxFileOutputFlag { get; set; }
-
+    
     public ControlMiscOptions()
     {
       InitializeComponent();

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -61,6 +61,8 @@ namespace Nmfs.Agepro.Gui
 
     }
 
+    #region Getters/Setters
+
     public bool MiscOptionsEnableSummaryReport
     {
       get => checkBoxEnableSummaryReport.Checked;
@@ -157,6 +159,40 @@ namespace Nmfs.Agepro.Gui
       set => dataGridRetroAdjustment.DataSource = value;
     }
     public string AgeproOutputViewer => comboBoxOutputViewerProgram.SelectedItem.ToString();
+
+    #endregion
+
+    #region Controls Setup
+
+    public void SetupSummaryStockFlagRadioButtons(AgeproMiscOptions inpData)
+    {
+      SummaryAuxFileOutputFlag = (StockSummaryFlag)inpData.OutputSummaryReport;
+
+      if (SummaryAuxFileOutputFlag == StockSummaryFlag.None)
+      {
+        radioButtonNone.Checked = true;
+      }
+      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.SummaryOnly)
+      {
+        radioButtonSummaryOnly.Checked = true;
+      }
+      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.SummaryPlusAux2_10)
+      {
+        radioButtonSummaryNoAux1.Checked = true;
+      }
+      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.SummaryPlusAllAux)
+      {
+        radioButtonSummaryPlusAllAux.Checked = true;
+      }
+      else 
+      {
+        throw new Exception("Invaild");
+      }
+
+    }
+
+
+    #endregion
 
     #region Setup Data Binding
 

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -185,10 +185,10 @@ namespace Nmfs.Agepro.Gui
     /// <summary>
     /// Textbox data bindings
     /// </summary>
-    /// <param name="ctl"></param>
-    /// <param name="miscOptSrc"></param>
-    /// <param name="miscOptField"></param>
-    /// <param name="decimalZeroFormat"></param>
+    /// <param name="ctl"> <see cref="NftTextBox"/> Control </param>
+    /// <param name="miscOptSrc"> Generalized class that encapsulates AGEPRO's <see cref="CoreLib.AgeproOptionsProperty"/> Classes </param>
+    /// <param name="miscOptField"> Field names of specfic <see cref="AgeproOptionsProperty"/> class.</param>
+    /// <param name="decimalZeroFormat">Boolean flag to format to include point-decimal values.  </param>
     private void SetControlDataBindings(NftTextBox ctl, CoreLib.AgeproOptionsProperty miscOptSrc, string miscOptField,
       bool decimalZeroFormat = false)
     {
@@ -254,7 +254,8 @@ namespace Nmfs.Agepro.Gui
     }
 
     /// <summary>
-    /// 
+    /// Enable or Disable the Report Percentile UI elements by determining the 
+    /// "Request Perecentile Report" check box "checked" value it was was changed.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
@@ -397,7 +398,8 @@ namespace Nmfs.Agepro.Gui
     /// Row-count based auxilary stochastic file checker. Throws an warning dialog if row count is over the
     /// large file aize row count. 
     /// </summary>
-    /// <param name="auxFileRowSize"></param>
+    /// <param name="auxFileRowSize">Auxilary file row count.  
+    /// Size equals timeHorizon * numRealizations, which numRealizations is numBootstraps * numSims</param>
     /// <param name="largeFileRowCount">Default to 1000000 </param>
     /// <returns></returns>
     public bool CheckOutputFileRowSize(int auxFileRowSize, int largeFileRowCount = 1000000)
@@ -424,6 +426,10 @@ namespace Nmfs.Agepro.Gui
       return true;
     }
 
+    /// <summary>
+    /// Helper Function to Load The Retro Adjustments Data Grid from AGEPRO Input File
+    /// </summary>
+    /// <param name="inputFile">AGEPRO Input File Object</param>
     public void LoadRetroAdjustmentsFactorTable(AgeproInputFile inputFile)
     {
       if (MiscOptionsRetroAdjustmentFactorTable != null)

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -58,7 +58,7 @@ namespace Nmfs.Agepro.Gui
       //Report Percentile
       MiscOptionsReportPercentile = 0;
 
-      SummaryAuxFileOutputFlag = StockSummaryFlag.None;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.NoStockDistAllAux;
 
     }
 
@@ -176,21 +176,21 @@ namespace Nmfs.Agepro.Gui
     {
       SummaryAuxFileOutputFlag = (StockSummaryFlag)inpData.OutputSummaryReport;
 
-      if (SummaryAuxFileOutputFlag == StockSummaryFlag.None)
+      if (SummaryAuxFileOutputFlag == StockSummaryFlag.NoStockDistAllAux)
       {
-        radioButtonNone.Checked = true;
+        radioButtonNoStockDistAllAux.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.SummaryOnly)
+      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.StockDistAllAux)
       {
-        radioButtonSummaryOnly.Checked = true;
+        radioButtonStockDistAllAux.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.SummaryPlusAux2_10)
+      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.StockDistNoAux)
       {
-        radioButtonSummaryNoAux1.Checked = true;
+        radioButtonSummaryStockDistNoAux.Checked = true;
       }
-      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.SummaryPlusAllAux)
+      else if (SummaryAuxFileOutputFlag == StockSummaryFlag.StockDistExceptAuxStockVector)
       {
-        radioButtonSummaryPlusAllAux.Checked = true;
+        radioButtonStockDistExceptAuxStockVector.Checked = true;
       }
       else 
       {
@@ -673,22 +673,22 @@ namespace Nmfs.Agepro.Gui
 
     private void RadioButtonNone_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = StockSummaryFlag.None;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.NoStockDistAllAux;
     }
 
     private void RadioButtonSummaryOnly_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = StockSummaryFlag.SummaryOnly;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.StockDistAllAux;
     }
 
     private void RadioButtonSummaryNoAux1_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = StockSummaryFlag.SummaryPlusAux2_10;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.StockDistNoAux;
     }
 
     private void RadioButtonSummaryPlusAllAux_CheckedChanged(object sender, EventArgs e)
     {
-      SummaryAuxFileOutputFlag = StockSummaryFlag.SummaryPlusAllAux;
+      SummaryAuxFileOutputFlag = StockSummaryFlag.StockDistExceptAuxStockVector;
     }
 
     private void CheckBoxEnableSummaryReport_CheckedChanged(object sender, EventArgs e)

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
+using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 
@@ -31,8 +32,7 @@ namespace Nmfs.Agepro.Gui
 
     public int miscOptionsNumAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
-    //Local Variable to set inpfile format
-    public string inpfileFormat { get; set; }
+    
     
     public ControlMiscOptions()
     {
@@ -62,13 +62,15 @@ namespace Nmfs.Agepro.Gui
       SummaryAuxFileOutputFlag = AuxiliaryOutputFlag.NoStockAge_ExcludeStockNumAuxFile;
 
       //By Default, Set inpfile format to version string
-      inpfileFormat = Nmfs.Agepro.CoreLib.Resources.Version.INP_VersionString;
+      MiscOptionsInpfileFormat = CoreLib.Resources.Version.INP_VersionString;
 
     }
 
     #region Getters/Setters
 
     public AuxiliaryOutputFlag SummaryAuxFileOutputFlag { get; set; }
+
+    public string MiscOptionsInpfileFormat { get; set; }
 
     public bool MiscOptionsEnableAuxStochasticFiles
     {
@@ -165,8 +167,20 @@ namespace Nmfs.Agepro.Gui
     public bool MiscOptionsEnableVer40Format
     {
       get => checkBoxEnableVer40Format.Checked;
-      set => checkBoxEnableVer40Format.Checked = value;
+      set
+      {
+        checkBoxEnableVer40Format.Checked = value;
+        if (MiscOptionsEnableVer40Format)
+        {
+          MiscOptionsInpfileFormat = CoreLib.Resources.Version.INP_AGEPRO40_VersionString;
+          
+        }
+        else
+        {
+          MiscOptionsInpfileFormat = CoreLib.Resources.Version.INP_VersionString;
+        }
 
+      }
     }
 
     public string AgeproOutputViewer => comboBoxOutputViewerProgram.SelectedItem.ToString();
@@ -365,7 +379,8 @@ namespace Nmfs.Agepro.Gui
       }
 
       //Input File Format
-      inpfileFormat = inputFile.Version;
+      MiscOptionsInpfileFormat = inputFile.Version;
+      MiscOptionsEnableVer40Format = MiscOptionsInpfileFormat.Equals(CoreLib.Resources.Version.INP_AGEPRO40_VersionString);
 
       miscOptionsNumAges = inputFile.General.NumAges();
       miscOptionsFirstAge = inputFile.General.AgeBegin;
@@ -694,6 +709,7 @@ namespace Nmfs.Agepro.Gui
       radioButtonNoStockAge_NoAux.Enabled = !checkBoxEnableVer40Format.Checked;
       radioButtonStockAge_NoAux.Enabled = !checkBoxEnableVer40Format.Checked;
       radioButtonStockAge_ExcludeStockNumAux.Enabled = !checkBoxEnableVer40Format.Checked;
+     
     }
 
     /// <summary>

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -22,6 +22,11 @@ namespace Nmfs.Agepro.Gui
   /// </summary>
   public partial class ControlMiscOptions : UserControl
   {
+    private const string DefaultRefJan1Biomass = "0.0";
+    private const string DefaultRefMeanBiomass = "0.0";
+    private const string DefaultRefSpawnBiomass = "0.0";
+    private const string DefaultRefFishingMortality = "0.0";
+
     public int miscOptionsNAges { get; set; }
     public int miscOptionsFirstAge { get; set; }
 
@@ -37,10 +42,10 @@ namespace Nmfs.Agepro.Gui
       MiscOptionsBoundsNaturalMortality = "1.0";
 
       //Refpoints
-      MiscOptionsRefJan1Biomass = "0.0";
-      MiscOptionsRefMeanBiomass = "0.0";
-      MiscOptionsRefSpawnBiomass = "0.0";
-      MiscOptionsRefFishingMortality = "0.0";
+      MiscOptionsRefJan1Biomass = DefaultRefJan1Biomass;
+      MiscOptionsRefMeanBiomass = DefaultRefMeanBiomass;
+      MiscOptionsRefSpawnBiomass = DefaultRefSpawnBiomass;
+      MiscOptionsRefFishingMortality = DefaultRefFishingMortality;
 
       //Scale Factors
       MiscOptionsScaleFactorBiomass = "0.0";
@@ -396,27 +401,18 @@ namespace Nmfs.Agepro.Gui
     /// <returns></returns>
     public bool ValidateMiscOptions()
     {
-      List<string> errorMsgList = new List<string>();
-      //Reference Points
       if (MiscOptionsEnableRefpointsReport)
       {
-        if (string.IsNullOrWhiteSpace(MiscOptionsRefJan1Biomass))
-        {
-          MiscOptionsRefJan1Biomass = "0.0";
-        }
-        if (string.IsNullOrWhiteSpace(MiscOptionsRefMeanBiomass))
-        {
-          MiscOptionsRefMeanBiomass = "0.0";
-        }
-        if (string.IsNullOrWhiteSpace(MiscOptionsRefSpawnBiomass))
-        {
-          MiscOptionsRefSpawnBiomass = "0.0";
-        }
-        if (string.IsNullOrWhiteSpace(MiscOptionsRefFishingMortality))
-        {
-          MiscOptionsRefFishingMortality = "0.0";
-        }
+        //Reference Points: Replace null/empty(whitespace) values to default
+        MiscOptionsRefJan1Biomass = string.IsNullOrWhiteSpace(MiscOptionsRefJan1Biomass) ? DefaultRefJan1Biomass : MiscOptionsRefJan1Biomass;
+        MiscOptionsRefMeanBiomass = string.IsNullOrWhiteSpace(MiscOptionsRefMeanBiomass) ? DefaultRefMeanBiomass : MiscOptionsRefMeanBiomass;
+        MiscOptionsRefSpawnBiomass = string.IsNullOrWhiteSpace(MiscOptionsRefSpawnBiomass) ? DefaultRefSpawnBiomass : MiscOptionsRefSpawnBiomass;
+        MiscOptionsRefFishingMortality = string.IsNullOrWhiteSpace(MiscOptionsRefFishingMortality) ? DefaultRefFishingMortality : MiscOptionsRefFishingMortality;
       }
+      
+      //Log Errors
+      List<string> errorMsgList = new List<string>();
+      
       //Retrospective Adjustment Factors
       if (dataGridRetroAdjustment.HasBlankOrNullCells())
       {

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -690,6 +690,7 @@ namespace Nmfs.Agepro.Gui
     #endregion
     private void checkBoxEnableVer40Format_CheckedChanged(object sender, EventArgs e)
     {
+      MiscOptionsEnableVer40Format = checkBoxEnableVer40Format.Checked;
       radioButtonNoStockAge_NoAux.Enabled = !checkBoxEnableVer40Format.Checked;
       radioButtonStockAge_NoAux.Enabled = !checkBoxEnableVer40Format.Checked;
       radioButtonStockAge_ExcludeStockNumAux.Enabled = !checkBoxEnableVer40Format.Checked;

--- a/src/ui/formAgepro/options/ControlMiscOptions.cs
+++ b/src/ui/formAgepro/options/ControlMiscOptions.cs
@@ -8,7 +8,17 @@ using System.Windows.Forms;
 namespace Nmfs.Agepro.Gui
 {
   /// <summary>
-  /// Settings for AGEPRO output and optional parameters.
+  /// 
+  /// <para>
+  /// Settings for AGEPRO's output options (OPTIONS) and its additional optional options:
+  /// <list type="bullet">
+  ///   <item> PERC - User Percentile Summary </item>
+  ///   <item> REFPOINT - Reference Points </item>
+  ///   <item> SCALE - Scaling Factors </item>
+  ///   <item> BOUNDS - Max Bounds </item>
+  ///   <item> RETROADJUST - Retrospective Adjustmentment Factors </item>
+  /// </list>
+  /// </para>
   /// </summary>
   public partial class ControlMiscOptions : UserControl
   {
@@ -333,6 +343,12 @@ namespace Nmfs.Agepro.Gui
       }
     }
 
+    /// <summary>
+    /// Sets Misc Options values from AGEPRO Input File.
+    /// 
+    /// </summary>
+    /// <param name="inputFile"> AGEPRO Input File </param>
+    /// <exception cref="ArgumentNullException"></exception>
     public void SetMiscOptionsControlsFromInputFile(AgeproInputFile inputFile)
     {
       if (inputFile is null)

--- a/src/ui/formAgepro/options/StockSummaryFlag.cs
+++ b/src/ui/formAgepro/options/StockSummaryFlag.cs
@@ -3,10 +3,10 @@ namespace Nmfs.Agepro.Gui.src.ui.formAgepro.options
 {
   public enum StockSummaryFlag
   {
-    None,
-    OnlySummary,
-    SummaryPlusAuxFiles_ExcludeStockAgeAuxFile,
-    SummaryPlusAllAuxFiles
+    NoStockDistAllAux,
+    StockDistAllAux,
+    StockDistNoAux,
+    StockDistExceptAuxStockVector
 
   }
 }

--- a/src/ui/formAgepro/options/StockSummaryFlag.cs
+++ b/src/ui/formAgepro/options/StockSummaryFlag.cs
@@ -1,0 +1,12 @@
+﻿
+namespace Nmfs.Agepro.Gui.src.ui.formAgepro.options
+{
+  public enum StockSummaryFlag
+  {
+    None,
+    OnlySummary,
+    SummaryPlusAuxFiles_ExcludeStockAgeAuxFile,
+    SummaryPlusAllAuxFiles
+
+  }
+}

--- a/src/ui/formAgepro/stochastic/ControlStochasticAge.cs
+++ b/src/ui/formAgepro/stochastic/ControlStochasticAge.cs
@@ -321,6 +321,11 @@ namespace Nmfs.Agepro.Gui
             AgeproStochasticAgeTable.ReadStochasticTableFile(StochasticDataFile, numAges);
       }
 
+      // Invalidate if stochasticTableToCheckBounds is still null
+      if(stochasticTableToCheckBounds == null) { 
+        return false; 
+      }
+
       //Check if a cell/item has excceded the upper bound.     
       foreach (DataRow rowLines in stochasticTableToCheckBounds.Rows)
       {


### PR DESCRIPTION
- AGEPRO-GUI Support for changes to the output option OutputSummaryFlag/AuxiliayOutputFlag introduced in AGEPRO Calculation Engine version 4.25 
  - The **Misc Options** checkbox option *Output Summary Report at Stock Numbers at Age* is replaced by *Stock Of Age Distribution and Auxiliary Files Output* group box allows users to select an Auxiliary Output Flag. 
  - If `AGEPRO VERSION 4.0` Input File format is loaded, only the first two radio buttons are enabled 
- Support for File Current version Format (AGEPRO VERSION 4.25) and "AGEPRO VERSION 4.0"
    - **NOTE**: AGEPRO-GUI will run only on the `AGEPRO VERSION 4.0` and current version `AGEPRO VERSION 4.25` input file format. 
    - Added text box in general options to show the current format of the AGEPRO input file. To toggle between the Current Version and `AGEPRO VERSION 4.0`, goto **Misc Options** and toggle the check box saying "Enable AGEPRO VERSION 4.0 Input File Format"  
  - Added Version String Resources: GUI Version variable, input file string, and numeric style versioning format identifier for the AGEPRO calculation engine.
- Refactor for `RetroAdjustment` Consistency
- Store path of Loaded AGEPRO Input File (https://github.com/PIFSCstockassessments/AGEPRO-GUI/issues/22)
- Fixup ObsYears( validation causing an false "Invalid Rebuild and P-Star Year Specification" validation (https://github.com/PIFSCstockassessments/AGEPRO-GUI/issues/27)
Improve handling BootstrapFile prior to AGEPRO model launch to calcuation engine:
- Fixed method to check if bootstrap file is in the same path as the input file.
  - Clarified dialog text for this validation check.
  - Implemented `bootstrapFile` value replacement if requested.
  - Added Conformation Dialog prior to validation
  - Refactored control flow statements
- FIX: Rebuilder Target Values can now be saved to Input Files
- GitHub Bug Report Templates (https://github.com/PIFSCstockassessments/AGEPRO-GUI/pull/23)
- Clarify an ambiguous and unreadable error prompt that an Agepro Output file doesn't exist on the target calculation run path.
- Code Documentation and Refactoring
  - NftTextBox Code Documentation
  - Rename:
    - Rename Strings.resx -> AgeproStrings.resx 
    - Rename SummaryAuxFileOutput -> SummaryAuxFileOutputFlag
    - rename miscOptionsNAges -> miscOptionsNumAges
    - Rename SetupRetroAdjustmentFactorsControlFromUserInput -> SetupRetroAdjustmentsFactorControl
    - Rename SetRetroAdjustmentFactorRowHeaders -> SetupRetroAdjustmentsFactorRowHeaders
    - Rename BindMiscOptionsControlValuesToCoreLib -> ControlMiscOptionsDataBindings
    - Rename SetMiscOptionsFromInputFile -> SetupControlFromFile
    - Rename SetControlDataBindings -> SetupTextBoxDataBindings
    - Rename SetupSummaryStockSummaryStockFlagRadioButtons -> SetupGroupSummaryStockFlag
    - Rename StockSummaryFlag -> AuxiliaryOutputFlag
  - Use `#Region` to organize related functions
- README updates
- Update to Target .NET Framework 4.8
